### PR TITLE
Feature/settings page

### DIFF
--- a/concordia_nav/lib/core/ui/widgets/custom_appbar.dart
+++ b/concordia_nav/lib/core/ui/widgets/custom_appbar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'settings_page.dart';
 
 // Custom AppBar widget that accepts a title
 PreferredSizeWidget customAppBar(BuildContext context, String title) {
@@ -14,7 +15,11 @@ PreferredSizeWidget customAppBar(BuildContext context, String title) {
     centerTitle: true,
     leading: IconButton(
       onPressed: () {
-        // TODO: Implement the settings page.
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (BuildContext context) {
+            return const SettingsPage();
+          }),
+        );
       },
       icon: const Icon(
         Icons.settings,

--- a/concordia_nav/lib/core/ui/widgets/settings_page.dart
+++ b/concordia_nav/lib/core/ui/widgets/settings_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
+import 'settings_tile.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
 
-  /// The Settings page, which displays a list of options
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -26,6 +26,59 @@ class SettingsPage extends StatelessWidget {
             color: Colors.white,
           ),
         ),
+      ),
+      body: ListView(
+        children: [
+          SettingsTile(
+            icon: Icons.calendar_today,
+            title: 'My calendar',
+            onTap: () {
+              // TODO: Implement navigation to Calendar page.
+            },
+          ),
+          SettingsTile(
+            icon: Icons.notifications,
+            title: 'Notifications',
+            onTap: () {
+              // TODO: Implement navigation to Notifications page.
+            },
+          ),
+          SettingsTile(
+            icon: Icons.tune,
+            title: 'Preferences',
+            onTap: () {
+              // TODO: Implement navigation to Preferences page.
+            },
+          ),
+          SettingsTile(
+            icon: Icons.accessibility,
+            title: 'Accessibility',
+            onTap: () {
+              // TODO: Implement navigation to Accessibility page
+            },
+          ),
+          SettingsTile(
+            icon: Icons.phone,
+            title: 'Contact',
+            onTap: () {
+              // TODO: Implement navigation to Contact page.
+            },
+          ),
+          SettingsTile(
+            icon: Icons.info_outline,
+            title: 'Guide',
+            onTap: () {
+              // TODO: Implement navigation to Guide page.
+            },
+          ),
+          SettingsTile(
+            icon: Icons.login,
+            title: 'Login',
+            onTap: () {
+              // TODO: Implement navigation to Login page.
+            },
+          ),
+        ],
       ),
     );
   }

--- a/concordia_nav/lib/core/ui/widgets/settings_page.dart
+++ b/concordia_nav/lib/core/ui/widgets/settings_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  /// The Settings page, which displays a list of options
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).primaryColor,
+        title: const Text(
+          'Settings',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 20,
+          ),
+        ),
+        centerTitle: true,
+        leading: IconButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          icon: const Icon(
+            Icons.arrow_back,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/concordia_nav/lib/core/ui/widgets/settings_tile.dart
+++ b/concordia_nav/lib/core/ui/widgets/settings_tile.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class SettingsTile extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final VoidCallback onTap;
+
+  const SettingsTile({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: Icon(icon),
+        title: Text(title),
+        trailing: const Icon(Icons.arrow_forward_ios),
+        contentPadding: const EdgeInsets.all(10),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/concordia_nav/test/custom_appbar_test.dart
+++ b/concordia_nav/test/custom_appbar_test.dart
@@ -90,5 +90,42 @@ void main() {
       expect(actualIcon.icon, expectedIcon.icon); // Compare IconData
       expect(actualIcon.color, expectedIcon.color); // Compare color
     });
+
+    testWidgets('tapping the Settings button should bring to settingspage', (WidgetTester tester) async {
+      // Build the customAppBar inside a MaterialApp
+      await tester.pumpWidget(const MaterialApp(home: const HomePage()));
+
+      // Ensure the widget tree is rendered
+      await tester.pump();
+
+      // find the Settings icon and tap it
+      await tester.tap(find.byIcon(Icons.settings));
+
+      // wait till the screen changes
+      await tester.pumpAndSettle();
+
+      // should be in the Settings page
+      expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('back button in the Settings page brings back to home', (WidgetTester tester) async {
+      // Build the customAppBar inside a MaterialApp
+      await tester.pumpWidget(const MaterialApp(home: const HomePage()));
+      await tester.pump();
+
+      // find the Settings icon and tap it
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+      expect(find.text('Settings'), findsOneWidget);
+
+      // find back button in settings page and tap it 
+      await tester.tap(find.byIcon(Icons.arrow_back));
+
+      // wait till the screen changes
+      await tester.pumpAndSettle();
+
+      // should be in the Home page
+      expect(find.text('Home'), findsOneWidget);
+    });
   });
 }

--- a/concordia_nav/test/settingspage_test.dart
+++ b/concordia_nav/test/settingspage_test.dart
@@ -1,0 +1,115 @@
+import 'package:concordia_nav/core/ui/widgets/settings_page.dart';
+import 'package:concordia_nav/core/ui/widgets/settings_tile.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  group('settingsAppBar', () {
+    testWidgets('appBar has the right title', (WidgetTester tester) async {
+      // Build the SettingsPage widget
+      await tester.pumpWidget(const MaterialApp(home: const SettingsPage()));
+
+      await tester.pump();
+
+      // Verify that the appBar exists and has the right title
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+    });
+
+    testWidgets('appBar leading IconButton should include a back button', (WidgetTester tester) async {
+      // Build the SettingsPage widget
+      await tester.pumpWidget(const MaterialApp(home: const SettingsPage()));
+
+      await tester.pump();
+
+      // Find the leading IconButton
+      final IconButton leadingIconButton = tester.widget(
+        find.descendant(of: find.byType(AppBar), matching: find.byType(IconButton).first),
+      );
+
+      const expectedIcon = const Icon(Icons.arrow_back, color: Colors.white);
+      final actualIcon = leadingIconButton.icon as Icon;
+
+      expect(actualIcon.icon, expectedIcon.icon);
+      expect(actualIcon.color, expectedIcon.color);
+    });
+  });
+
+  group('settingTiles', () {
+    testWidgets('list of SettingsTiles are present', (WidgetTester tester) async {
+      // Build the SettingsPage widget
+      await tester.pumpWidget(const MaterialApp(home: const SettingsPage()));
+
+      // Verify that exactly 7 SettingsTile exist
+      expect(find.byType(SettingsTile), findsNWidgets(7));
+    });
+
+    testWidgets('list of SettingsTiles are accurate', (WidgetTester tester) async {
+      // Build the SettingsPage widget
+      await tester.pumpWidget(const MaterialApp(home: const SettingsPage()));
+
+      // Verify that the My Calendar SettingsTile text and icon are present
+      expect(find.text('My calendar'), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_today), findsOneWidget);
+
+      // Verify that the Notifications SettingsTile text and icon are present
+      expect(find.text('Notifications'), findsOneWidget);
+      expect(find.byIcon(Icons.notifications), findsOneWidget);
+
+      // Verify that the Preferences SettingsTile text and icon are present
+      expect(find.text('Preferences'), findsOneWidget);
+      expect(find.byIcon(Icons.tune), findsOneWidget);
+
+      // Verify that the Accessibility SettingsTile text and icon are present
+      expect(find.text('Accessibility'), findsOneWidget);
+      expect(find.byIcon(Icons.accessibility), findsOneWidget);
+
+      // Verify that the Contact SettingsTile text and icon are present
+      expect(find.text('Contact'), findsOneWidget);
+      expect(find.byIcon(Icons.phone), findsOneWidget);
+
+      // Verify that the Guide SettingsTile text and icon are present
+      expect(find.text('Guide'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+
+      // Verify that the Login SettingsTile text and icon are present
+      expect(find.text('Login'), findsOneWidget);
+      expect(find.byIcon(Icons.login), findsOneWidget);
+    });
+
+    testWidgets('SettingsTile onPress is possible', (WidgetTester tester) async {
+      // Build the SettingsPage widget
+      await tester.pumpWidget(const MaterialApp(home: const SettingsPage()));
+
+      // Tap on My Calendar SettingsTile
+      await tester.tap(find.text('My calendar'));
+      await tester.pump();
+
+      // Tap on Notifications SettingsTile
+      await tester.tap(find.text('Notifications'));
+      await tester.pump();
+
+      // Tap on Preferences SettingsTile
+      await tester.tap(find.text('Preferences'));
+      await tester.pump();
+
+      // Tap on Accessibility SettingsTile
+      await tester.tap(find.text('Accessibility'));
+      await tester.pump();
+
+      // Tap on Contact SettingsTile
+      await tester.tap(find.text('Contact'));
+      await tester.pump();
+
+      // Tap on Guide SettingsTile
+      await tester.tap(find.text('Guide'));
+      await tester.pump();
+
+      // Tap on Login SettingsTile
+      await tester.ensureVisible(find.text('Login'));
+      await tester.pumpAndSettle(); // ensures and waits for the SettingsTile to be visible in the renderbox
+      await tester.tap(find.text('Login'));
+      await tester.pump();
+    });
+  });
+}


### PR DESCRIPTION
### 🛠 Proposed Changes:

Implement the Settings page with options using the SettingsTile widget and add a transition from Main Menu.

### 📝 Details:

- Create the Settings page
- Create SettingsTile widget for different options
- Add transition from Main Menu to Settings page

![Screenshot 2025-02-01 at 6 29 34 PM](https://github.com/user-attachments/assets/d623cae3-56fb-4dc6-8393-bdad3b9fa020)

### 🔗 Related Issue(s):

- Resolves #48 
- Resolves #64 