### PR TITLE
ci: fail fast when tests fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Cancel workflow on failure
       if: failure()
-      uses: vishnudxb/cancel-workflow-action@v1.2
+      uses: vishnudxb/cancel-workflow@v1.2
       with:
         repo: ${{ github.repository }}
         workflow_id: ${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  actions: write
+
 jobs:
   test:
     name: 🧪 Run Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,6 @@ jobs:
     - name: Run unit tests
       run: rps test unit
 
-    - name: Fail
-      run: exit 1
-
     - name: Cancel workflow on failure
       if: failure()
       uses: vishnudxb/cancel-workflow@v1.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,18 @@ jobs:
     
     - name: Run unit tests
       run: rps test unit
+
+    - name: Fail
+      run: exit 1
+
+    - name: Cancel workflow on failure
+      if: failure()
+      uses: vishnudxb/cancel-workflow-action@v1.2
+      with:
+        repo: ${{ github.repository }}
+        workflow_id: ${{ github.run_id }}
+        access_token: ${{ github.token }}
+
     
     # - name: Enable KVM group perms
     #   if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
### 🛠 Proposed Changes:

Fail fast when the test job of the continuous integration workflow fails.

There is a downside with this change. It's now a lot harder to see what went wrong from a glance. However, you can still view each job and see which one was the cause of the error (usually going to be test).