### PR TITLE
Add default return value for getRoundedLocation

### DIFF
--- a/concordia_nav/lib/data/services/indoor_routing_service.dart
+++ b/concordia_nav/lib/data/services/indoor_routing_service.dart
@@ -19,6 +19,7 @@ import 'map_service.dart';
 
 class IndoorRoutingService {
   static const roundingMinimumProximityMeters = 30.0;
+  static const defaultLocation = BuildingRepository.h;
 
   /// Returns at minimum a Location object with latitide and longitude based on
   /// the device location. If the device is within the minimum rounding
@@ -38,11 +39,11 @@ class IndoorRoutingService {
           await mapService.checkAndRequestLocationPermission();
       // check if location services are enabled
       if (!serviceEnabled) {
-        return Future.error('Location services are disabled.');
+        return defaultLocation;
       }
       // check if location permissions are granted
       if (!hasPermission) {
-        return Future.error('Location permissions are denied.');
+        return defaultLocation;
       }
 
       // Get the user's current location
@@ -50,11 +51,11 @@ class IndoorRoutingService {
           locationSettings: const LocationSettings(
               accuracy: LocationAccuracy.bestForNavigation));
     } on Exception {
-      return null;
+      return defaultLocation;
     }
 
     // Discard location if wildly inaccurate
-    if (userPosition.accuracy > 50.0) return null;
+    if (userPosition.accuracy > 50.0) return defaultLocation;
 
     // Search through the appropriate list of buildings if the user is close to
     // either campus

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
@@ -127,7 +127,7 @@ void main() async {
   });
 
   group('IndoorRoutingService', () {
-    test('should return null when Geolocator throws an exception', () async {
+    test('should return H building when Geolocator throws an exception', () async {
       // Arrange
       final mockGeolocator = MockGeolocatorPlatform();
       when(mockGeolocator.getCurrentPosition(
@@ -138,7 +138,7 @@ void main() async {
       final result = await IndoorRoutingService.getRoundedLocation();
 
       // Assert
-      expect(result, isNull);
+      expect(result, BuildingRepository.h);
     });
   });
 
@@ -238,7 +238,7 @@ void main() async {
         expect(res?.name, "Richard J. Renaud Science Complex");
       });
 
-      test('returns null when accuracy > 50', () async {
+      test('returns Hall building when accuracy > 50', () async {
         // position with accuracy > 50
         testPosition = Position(
             longitude: -73.5788992164221,
@@ -252,22 +252,20 @@ void main() async {
             altitudeAccuracy: 0.0,
             headingAccuracy: 0.0);
         final res = await IndoorRoutingService.getRoundedLocation();
-        expect(res, null); // should return null
+        expect(res, BuildingRepository.h);
       });
 
-      test('returns error message if service disabled', () async {
+      test('returns Hall building if service disabled', () async {
         service = false;
-        // should return an error
-        expect(IndoorRoutingService.getRoundedLocation(),
-            throwsA('Location services are disabled.'));
+        final res = await IndoorRoutingService.getRoundedLocation();
+        expect(res, BuildingRepository.h); 
       });
 
       test('returns error message if service disabled', () async {
         service = true;
         permission = 1;
-        // should return an error
-        expect(IndoorRoutingService.getRoundedLocation(),
-            throwsA('Location permissions are denied.'));
+        final res = await IndoorRoutingService.getRoundedLocation();
+        expect(res, BuildingRepository.h);
       });
     });
   });


### PR DESCRIPTION
Relates to #288

### 🛠 Proposed Changes:

Adds a default return value for getRoundedLocation() and updates the test. However, there are currently no references to this method. It is a baseline for future features (eg. TSP). The current location-disabled issues will need to be addressed by front. @CarciDev 