### PR TITLE
Feature/current classroom callback

### DIFF
--- a/concordia_nav/lib/data/repositories/calendar.dart
+++ b/concordia_nav/lib/data/repositories/calendar.dart
@@ -73,14 +73,16 @@ class CalendarRepository {
   /// Retrieves events from the list of selected calendars for the given
   /// duration.
   Future<List<UserCalendarEvent>> getEvents(
-      List<UserCalendar> selectedCalendars,
+      List<UserCalendar>? selectedCalendars,
       Duration timeSpan,
       DateTime? utcStart) async {
+    // If selected calendars not passed, use all calendars
+    final calendars = selectedCalendars ?? await getUserCalendars();
     final List<UserCalendarEvent> returnData = [];
     final startDate = (utcStart ?? DateTime.now().toUtc());
     final endDate = startDate.add(timeSpan);
 
-    for (var userCalendar in selectedCalendars) {
+    for (var userCalendar in calendars) {
       final systemCalendarEvents = await plugin.retrieveEvents(
           userCalendar.calendarId,
           RetrieveEventsParams(startDate: startDate, endDate: endDate));
@@ -111,7 +113,7 @@ class CalendarRepository {
   /// Helper method to get events on a given local date from today. Pass 0 to
   /// get today's events.
   Future<List<UserCalendarEvent>> getEventsOnLocalDate(
-      List<UserCalendar> selectedCalendars, int offset) async {
+      List<UserCalendar>? selectedCalendars, int offset) async {
     var startDate = DateTime.now().add(Duration(days: offset));
     startDate =
         DateTime(startDate.year, startDate.month, startDate.day, 0, 0, 0, 0, 0);

--- a/concordia_nav/lib/data/services/indoor_routing_service.dart
+++ b/concordia_nav/lib/data/services/indoor_routing_service.dart
@@ -19,6 +19,7 @@ import 'map_service.dart';
 
 class IndoorRoutingService {
   static const roundingMinimumProximityMeters = 30.0;
+  static const defaultLocation = BuildingRepository.h;
 
   /// Returns at minimum a Location object with latitide and longitude based on
   /// the device location. If the device is within the minimum rounding
@@ -38,11 +39,11 @@ class IndoorRoutingService {
           await mapService.checkAndRequestLocationPermission();
       // check if location services are enabled
       if (!serviceEnabled) {
-        return Future.error('Location services are disabled.');
+        return defaultLocation;
       }
       // check if location permissions are granted
       if (!hasPermission) {
-        return Future.error('Location permissions are denied.');
+        return defaultLocation;
       }
 
       // Get the user's current location
@@ -50,11 +51,11 @@ class IndoorRoutingService {
           locationSettings: const LocationSettings(
               accuracy: LocationAccuracy.bestForNavigation));
     } on Exception {
-      return null;
+      return defaultLocation;
     }
 
     // Discard location if wildly inaccurate
-    if (userPosition.accuracy > 50.0) return null;
+    if (userPosition.accuracy > 50.0) return defaultLocation;
 
     // Search through the appropriate list of buildings if the user is close to
     // either campus

--- a/concordia_nav/lib/data/services/indoor_routing_service.dart
+++ b/concordia_nav/lib/data/services/indoor_routing_service.dart
@@ -19,7 +19,6 @@ import 'map_service.dart';
 
 class IndoorRoutingService {
   static const roundingMinimumProximityMeters = 30.0;
-  static const defaultLocation = BuildingRepository.h;
 
   /// Returns at minimum a Location object with latitide and longitude based on
   /// the device location. If the device is within the minimum rounding
@@ -39,11 +38,11 @@ class IndoorRoutingService {
           await mapService.checkAndRequestLocationPermission();
       // check if location services are enabled
       if (!serviceEnabled) {
-        return defaultLocation;
+        return Future.error('Location services are disabled.');
       }
       // check if location permissions are granted
       if (!hasPermission) {
-        return defaultLocation;
+        return Future.error('Location permissions are denied.');
       }
 
       // Get the user's current location
@@ -51,11 +50,11 @@ class IndoorRoutingService {
           locationSettings: const LocationSettings(
               accuracy: LocationAccuracy.bestForNavigation));
     } on Exception {
-      return defaultLocation;
+      return null;
     }
 
     // Discard location if wildly inaccurate
-    if (userPosition.accuracy > 50.0) return defaultLocation;
+    if (userPosition.accuracy > 50.0) return null;
 
     // Search through the appropriate list of buildings if the user is close to
     // either campus

--- a/concordia_nav/lib/data/services/indoor_routing_service.dart
+++ b/concordia_nav/lib/data/services/indoor_routing_service.dart
@@ -8,17 +8,115 @@ import '../domain-model/concordia_building.dart';
 import '../domain-model/concordia_campus.dart';
 import '../domain-model/concordia_floor.dart';
 import '../domain-model/concordia_floor_point.dart';
+import '../domain-model/concordia_room.dart';
 import '../domain-model/connection.dart';
 import '../domain-model/floor_routable_point.dart';
 import '../domain-model/indoor_route.dart';
 import '../domain-model/location.dart';
 import '../repositories/building_data.dart';
+import '../repositories/building_data_manager.dart';
 import '../repositories/building_repository.dart';
+import '../repositories/calendar.dart';
 import '../repositories/indoor_feature_repository.dart';
 import 'map_service.dart';
 
 class IndoorRoutingService {
   static const roundingMinimumProximityMeters = 30.0;
+
+  static final firstRoomNumberParsingExp = RegExp(r'([A-Za-z -]+)(.+)');
+  static final calendarRepository = CalendarRepository();
+
+  /// Takes a string (as might appear in a calendar event location field) and parse it
+  /// into a room number.
+  ///
+  /// - first trim whitespace
+  /// - take all the letters and space characters off the left, trim, and match to a
+  ///   building abbreviation (null will be returned if this fails)
+  /// - then, if the rest of the string has a dot:
+  ///   - split the string on the first dot (only)
+  ///   - the left portion of the split is the floor and the right portion is the room
+  ///     number
+  /// - else (no dot):
+  ///   - if the rest of the string is 3 chars, first char is the floor and right 2
+  ///     chars are the room number
+  ///   - if the rest of the string is 4 chars, first 2 chars is the floor and right 2
+  ///     chars are the room number
+  ///
+  /// The canonical format is BBX.Y where BB is building abbreviation, X is floorNo
+  /// and Y is roomNumber. But this supports some other common formats.
+  ///
+  /// If there is room-level data for the floor, this will be returned, if not, only
+  /// the floor will be returned
+  ///
+  /// Examples:
+  ///   "EV2.260", "ev 2.260", "EV-2.260" -> EV, 2, 260
+  ///   "H6.55", "H655", "H 655" -> H, 6, 55
+  ///   "EV2260" -> EV (building level precision only, no floor 22 exists)
+  static Future<Location?> parseRoomNumber(String input) async {
+    // Split the input into alphabetic and numeric portions
+    Location? returnLocation;
+    var trimmed = input.trim();
+    var firstLevelMatch =
+        firstRoomNumberParsingExp.allMatches(trimmed).elementAt(0);
+    var buildingAbbrPortion = firstLevelMatch.group(1);
+    // If no alphabetic portion, can't give a location
+    if (buildingAbbrPortion == null) {
+      return returnLocation;
+    }
+    buildingAbbrPortion = buildingAbbrPortion.trim().toUpperCase();
+    returnLocation =
+        BuildingRepository.buildingByAbbreviation[buildingAbbrPortion];
+    if (returnLocation == null) {
+      return returnLocation;
+    }
+
+    // Deal with the floor - check we have a second portion of the input and building
+    // data for that building.
+    var buildingData =
+        await BuildingDataManager.getBuildingData(buildingAbbrPortion);
+    var floorAndRoomPortion = firstLevelMatch.group(2);
+    if (floorAndRoomPortion == null || buildingData == null) {
+      return returnLocation;
+    }
+
+    String? floorNumber;
+    String? roomNumber;
+    if (floorAndRoomPortion.contains('.')) {
+      var parts = floorAndRoomPortion.split('.');
+      floorNumber = parts[0].trim().toUpperCase();
+      roomNumber = parts.elementAtOrNull(1)?.trim();
+    } else {
+      if (floorAndRoomPortion.length == 3) {
+        floorNumber = floorAndRoomPortion.substring(0, 1);
+        roomNumber = floorAndRoomPortion.substring(1, 3);
+      } else if (floorAndRoomPortion.length == 4) {
+        floorNumber = floorAndRoomPortion.substring(0, 2);
+        roomNumber = floorAndRoomPortion.substring(2, 4);
+      }
+    }
+
+    if (floorNumber != null) {
+      for (ConcordiaFloor candidate in buildingData.floors) {
+        if (candidate.floorNumber == floorNumber) {
+          returnLocation = candidate;
+          break;
+        }
+      }
+    }
+
+    if (roomNumber != null &&
+        buildingData.roomsByFloor.containsKey(floorNumber)) {
+      for (ConcordiaRoom candidate
+          in buildingData.roomsByFloor[floorNumber] ?? []) {
+        if (candidate.roomNumber == roomNumber) {
+          returnLocation = candidate;
+          break;
+        }
+      }
+    }
+
+    return returnLocation;
+  }
 
   /// Returns at minimum a Location object with latitide and longitude based on
   /// the device location. If the device is within the minimum rounding
@@ -27,7 +125,7 @@ class IndoorRoutingService {
   ///
   /// Returns null if permission is denied or location services are not
   /// available.
-  static Future<Location?> getRoundedLocation() async {
+  static Future<Location?> getRoundedGeolocation() async {
     List<ConcordiaBuilding>? searchCandidates;
     final Position userPosition;
     final MapService mapService = MapService();
@@ -38,11 +136,11 @@ class IndoorRoutingService {
           await mapService.checkAndRequestLocationPermission();
       // check if location services are enabled
       if (!serviceEnabled) {
-        return Future.error('Location services are disabled.');
+        return null;
       }
       // check if location permissions are granted
       if (!hasPermission) {
-        return Future.error('Location permissions are denied.');
+        return null;
       }
 
       // Get the user's current location
@@ -100,6 +198,94 @@ class IndoorRoutingService {
       return Location(userPosition.latitude, userPosition.longitude,
           "Current Location", null, null, null, null);
     }
+  }
+
+  /// Iterates the events list. Returns a location if there is an event happening now or
+  /// within the specified tolerance of minutes and it has a parseable location. Takes
+  /// a now parameter to avoid inconsistent behaviour due to the clock ticking during
+  /// the execution of the method.
+  /// Otherwise returns null.
+  static Future<Location?> _iterateEventListWithTolerance(
+      ConcordiaBuilding? currentBuilding,
+      DateTime now,
+      List<UserCalendarEvent> eventsToday,
+      int minutesTolerance) async {
+    for (UserCalendarEvent event in eventsToday) {
+      var startTime = event.localStart;
+      var endTime = event.localEnd;
+      if (minutesTolerance > 0) {
+        startTime = startTime.subtract(Duration(minutes: minutesTolerance));
+      }
+      if (minutesTolerance < 0) {
+        endTime = endTime.add(Duration(minutes: minutesTolerance));
+      }
+      if (startTime.isBefore(now) &&
+          endTime.isAfter(now) &&
+          event.locationField != null) {
+        var eventLocation = await parseRoomNumber(event.locationField!);
+        if (eventLocation != null) return eventLocation;
+      }
+    }
+    return null;
+  }
+
+  /// If there is an in-progress calendar event, this will return the location of that
+  /// event if there is a parseable one (as above) or null if not.
+  ///
+  /// If there is no in-progress calendar event, it will first look back 15 minutes to
+  /// see if that event is parseable (eg. class ran overtime).
+  ///
+  /// If no previous event location was found, it will then look ahead 15 minutes to
+  /// see if that event is parseable for a location.
+  ///
+  /// If no location is found from these events, it will return null.
+  ///
+  /// If a ConcordiaBuilding is passed, only locations in this building will be accepted
+  /// in doing the evaluation.
+  static Future<Location?> getProximalCalendarEventLocation(
+      ConcordiaBuilding? currentBuilding) async {
+    // TODO we need to maintain some state for which calendars the user has selected
+    // in the settings. Right now we are looking at all calendars.
+    var eventsToday = await calendarRepository.getEventsOnLocalDate(null, 0);
+    var now = DateTime.now();
+    return await _iterateEventListWithTolerance(
+            currentBuilding, now, eventsToday, 0) ??
+        await _iterateEventListWithTolerance(
+            currentBuilding, now, eventsToday, -15) ??
+        await _iterateEventListWithTolerance(currentBuilding, now, eventsToday, 15);
+  }
+
+  /// This method uses geolocation and calendar data to decide where the user is to the
+  /// room level.
+  ///
+  /// If both geolocation and calendar are available/return a location, and the calendar
+  /// location is in the same building as the geolocation, it will return the calendar
+  /// event location.
+  ///
+  /// If both geolocation and calendar are available but disagree, it will return the
+  /// building-rounded geolocation.
+  ///
+  /// If either of the two sources are not available, it will return from the other
+  /// source.
+  ///
+  /// If neither of the two sources are available, it will return null.
+  static Future<Location?> getCurrentClassroom() async {
+    Location? geolocation = await getRoundedGeolocation();
+
+    if (geolocation != null && geolocation.runtimeType == ConcordiaBuilding) {
+      var calendarLocation = await getProximalCalendarEventLocation(
+          geolocation as ConcordiaBuilding);
+      if (calendarLocation != null) {
+        return calendarLocation;
+      }
+    }
+
+    if (geolocation != null) return geolocation;
+
+    var calendarLocation = await getProximalCalendarEventLocation(null);
+    if (calendarLocation != null) return calendarLocation;
+
+    return null;
   }
 
   static IndoorRoute _getDifferentBuildingRoute(

--- a/concordia_nav/pubspec.lock
+++ b/concordia_nav/pubspec.lock
@@ -218,10 +218,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -552,10 +552,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1053,10 +1053,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1093,10 +1093,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/concordia_nav/test/indoor_map/indoor_map_viewmodel_test.mocks.dart
+++ b/concordia_nav/test/indoor_map/indoor_map_viewmodel_test.mocks.dart
@@ -507,24 +507,6 @@ class MockIndoorMapViewModel extends _i1.Mock
           as _i9.Future<bool>);
 
   @override
-  _i9.Future<void> zoomIn() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomIn, []),
-            returnValue: _i9.Future<void>.value(),
-            returnValueForMissingStub: _i9.Future<void>.value(),
-          )
-          as _i9.Future<void>);
-
-  @override
-  _i9.Future<void> zoomOut() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomOut, []),
-            returnValue: _i9.Future<void>.value(),
-            returnValueForMissingStub: _i9.Future<void>.value(),
-          )
-          as _i9.Future<void>);
-
-  @override
   double getDistance(_i4.LatLng? point1, _i4.LatLng? point2) =>
       (super.noSuchMethod(
             Invocation.method(#getDistance, [point1, point2]),

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
@@ -127,7 +127,7 @@ void main() async {
   });
 
   group('IndoorRoutingService', () {
-    test('should return H building when Geolocator throws an exception', () async {
+    test('should return null when Geolocator throws an exception', () async {
       // Arrange
       final mockGeolocator = MockGeolocatorPlatform();
       when(mockGeolocator.getCurrentPosition(
@@ -138,7 +138,7 @@ void main() async {
       final result = await IndoorRoutingService.getRoundedLocation();
 
       // Assert
-      expect(result, BuildingRepository.h);
+      expect(result, isNull);
     });
   });
 
@@ -238,7 +238,7 @@ void main() async {
         expect(res?.name, "Richard J. Renaud Science Complex");
       });
 
-      test('returns Hall building when accuracy > 50', () async {
+      test('returns null when accuracy > 50', () async {
         // position with accuracy > 50
         testPosition = Position(
             longitude: -73.5788992164221,
@@ -252,20 +252,22 @@ void main() async {
             altitudeAccuracy: 0.0,
             headingAccuracy: 0.0);
         final res = await IndoorRoutingService.getRoundedLocation();
-        expect(res, BuildingRepository.h);
+        expect(res, null); // should return null
       });
 
-      test('returns Hall building if service disabled', () async {
+      test('returns error message if service disabled', () async {
         service = false;
-        final res = await IndoorRoutingService.getRoundedLocation();
-        expect(res, BuildingRepository.h); 
+        // should return an error
+        expect(IndoorRoutingService.getRoundedLocation(),
+            throwsA('Location services are disabled.'));
       });
 
       test('returns error message if service disabled', () async {
         service = true;
         permission = 1;
-        final res = await IndoorRoutingService.getRoundedLocation();
-        expect(res, BuildingRepository.h);
+        // should return an error
+        expect(IndoorRoutingService.getRoundedLocation(),
+            throwsA('Location permissions are denied.'));
       });
     });
   });

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
@@ -135,7 +135,7 @@ void main() async {
       )).thenThrow(Exception());
 
       // Act
-      final result = await IndoorRoutingService.getRoundedLocation();
+      final result = await IndoorRoutingService.getRoundedGeolocation();
 
       // Assert
       expect(result, isNull);
@@ -191,7 +191,7 @@ void main() async {
       });
 
       test('return current location when located far from campuses', () async {
-        final res = await IndoorRoutingService.getRoundedLocation();
+        final res = await IndoorRoutingService.getRoundedGeolocation();
 
         expect(res, isA<Location>());
         expect(res?.lat, 100.0);
@@ -211,7 +211,7 @@ void main() async {
             speedAccuracy: 0.0,
             altitudeAccuracy: 0.0,
             headingAccuracy: 0.0);
-        final res = await IndoorRoutingService.getRoundedLocation();
+        final res = await IndoorRoutingService.getRoundedGeolocation();
         // should return MB building
         expect(res, isA<ConcordiaBuilding>());
         expect(res?.lat, BuildingRepository.mb.lat);
@@ -231,7 +231,7 @@ void main() async {
             speedAccuracy: 0.0,
             altitudeAccuracy: 0.0,
             headingAccuracy: 0.0);
-        final res = await IndoorRoutingService.getRoundedLocation();
+        final res = await IndoorRoutingService.getRoundedGeolocation();
         // should return SP building
         expect(res, isA<ConcordiaBuilding>());
         expect(res?.lng, BuildingRepository.sp.lng);
@@ -251,23 +251,21 @@ void main() async {
             speedAccuracy: 0.0,
             altitudeAccuracy: 0.0,
             headingAccuracy: 0.0);
-        final res = await IndoorRoutingService.getRoundedLocation();
+        final res = await IndoorRoutingService.getRoundedGeolocation();
         expect(res, null); // should return null
       });
 
-      test('returns error message if service disabled', () async {
+      test('returns null when service disabled', () async {
         service = false;
-        // should return an error
-        expect(IndoorRoutingService.getRoundedLocation(),
-            throwsA('Location services are disabled.'));
+        final res = await IndoorRoutingService.getRoundedGeolocation();
+        expect(res, null); // should return null
       });
 
       test('returns error message if service disabled', () async {
         service = true;
         permission = 1;
-        // should return an error
-        expect(IndoorRoutingService.getRoundedLocation(),
-            throwsA('Location permissions are denied.'));
+        final res = await IndoorRoutingService.getRoundedGeolocation();
+        expect(res, null);
       });
     });
   });

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
@@ -5,6 +5,7 @@ import 'package:concordia_nav/data/domain-model/connection.dart';
 import 'package:concordia_nav/data/domain-model/location.dart';
 import 'package:concordia_nav/data/repositories/building_data.dart';
 import 'package:concordia_nav/data/repositories/building_repository.dart';
+import 'package:concordia_nav/data/repositories/calendar.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,13 +13,230 @@ import 'package:concordia_nav/data/services/indoor_routing_service.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import '../map/map_viewmodel_test.mocks.dart';
 import 'indoor_routing_service_test.mocks.dart';
 
-@GenerateMocks([GeolocatorPlatform])
+@GenerateMocks([GeolocatorPlatform, CalendarRepository])
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
 
+  // random position far away from campuses
+  var testPosition = Position(
+      longitude: 100.0,
+      latitude: 100.0,
+      timestamp: DateTime.now(),
+      accuracy: 30.0,
+      altitude: 20.0,
+      heading: 120,
+      speed: 150.9,
+      speedAccuracy: 10.0,
+      altitudeAccuracy: 10.0,
+      headingAccuracy: 10.0);
+  // ref to permission integers: https://github.com/Baseflow/flutter-geolocator/blob/main/geolocator_platform_interface/lib/src/extensions/integer_extensions.dart
+  var permission = 3; // permission set to accept
+  var request = 3; // request permission set to accept
+  var service = true; // locationService set to true
+
+  // ensure plugin is initialized
+  const MethodChannel locationChannel =
+      MethodChannel('flutter.baseflow.com/geolocator');
+
+  Future locationHandler(MethodCall methodCall) async {
+    // grants access to location permissions
+    if (methodCall.method == 'requestPermission') {
+      return request;
+    }
+    // return testPosition when searching for the current location
+    if (methodCall.method == 'getCurrentPosition') {
+      return testPosition.toJson();
+    }
+    // set to true when device tries to check for permissions
+    if (methodCall.method == 'isLocationServiceEnabled') {
+      return service;
+    }
+    // returns authorized when checking for location permissions
+    if (methodCall.method == 'checkPermission') {
+      return permission;
+    }
+  }
+
+  late CalendarRepository mockCalendarRepository;
+  late MockMapService mockMapService;
+
+  setUp(() {
+    mockMapService = MockMapService();
+    mockCalendarRepository = MockCalendarRepository();
+    permission = 3;
+    request = 3;
+    service = true;
+
+    testPosition = Position(
+        longitude: 100.0,
+        latitude: 100.0,
+        timestamp: DateTime.now(),
+        accuracy: 30.0,
+        altitude: 20.0,
+        heading: 120,
+        speed: 150.9,
+        speedAccuracy: 10.0,
+        altitudeAccuracy: 10.0,
+        headingAccuracy: 10.0);
+  });
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(locationChannel, locationHandler);
+  });
+
+  group('parseRoomNumber', () {
+    test('should return a valid location for valid input EV 123.101', () async {
+      expect(IndoorRoutingService.parseRoomNumber("EV 123.101"), isNotNull);
+    });
+    test('should return a valid location for valid input MB 45', () async {
+      expect(IndoorRoutingService.parseRoomNumber("MB 45"), isNotNull);
+    });
+    test('should return a valid location for valid input H-101', () async {
+      expect(IndoorRoutingService.parseRoomNumber("H-101"), isNotNull);
+    });
+    test('should return a valid location for valid input ABC 101', () async {
+      expect(IndoorRoutingService.parseRoomNumber("ABC 101"), isNotNull);
+    });
+    test('should return a valid location for valid input 123.101', () async {
+      expect(IndoorRoutingService.parseRoomNumber("123.101"), isNotNull);
+    });
+    test('should return a valid location for valid input ED 4.22', () async {
+      expect(IndoorRoutingService.parseRoomNumber("ED 4.22"), isNotNull);
+    });
+    test('should return a valid location for valid input MI 302', () async {
+      expect(IndoorRoutingService.parseRoomNumber("MI 302"), isNotNull);
+    });
+    test('should return a valid location for valid input MTL 501', () async {
+      expect(IndoorRoutingService.parseRoomNumber("MTL 501"), isNotNull);
+    });
+    test('should return a valid location for valid input H6.55', () async {
+      expect(IndoorRoutingService.parseRoomNumber("H9.27"), isNotNull);
+    });
+    test('should return a valid location for valid input H655', () async {
+      expect(IndoorRoutingService.parseRoomNumber("H930"), isNotNull);
+    });
+    test('should return a valid location for valid input H6555', () async {
+      expect(IndoorRoutingService.parseRoomNumber("H6555"), isNotNull);
+    });
+  });
+
+  group('getProximalCalendarEventLocation', () {
+    setUp(() {
+      mockCalendarRepository = MockCalendarRepository();
+      IndoorRoutingService.calendarRepository = mockCalendarRepository;
+    });
+
+    test('returns event location if there is an in-progress event', () async {
+      // Arrange
+      const mockBuilding = BuildingRepository.h;
+      var mockEventLocation = ConcordiaFloor("1", BuildingRepository.h);
+      final now = DateTime.now();
+      final eventsToday = [
+        UserCalendarEvent(
+          UserCalendar('1', 'Test Calendar'),
+          '1',
+          'Test Event',
+          now.subtract(const Duration(minutes: 5)),
+          now.add(const Duration(minutes: 10)),
+          'Test Event',
+          'H101',
+        ),
+      ];
+
+      when(mockCalendarRepository.getEventsOnLocalDate(null, 0))
+          .thenAnswer((_) async => eventsToday);
+
+      // Act
+      final result =
+          await IndoorRoutingService.getProximalCalendarEventLocation(
+              mockBuilding);
+
+      // Assert
+      expect(result, mockEventLocation);
+    });
+
+    test('returns null if there are no events today', () async {
+      // Arrange
+      const mockBuilding = BuildingRepository.h;
+      final eventsToday = <UserCalendarEvent>[];
+
+      when(mockCalendarRepository.getEventsOnLocalDate(null, 0))
+          .thenAnswer((_) async => eventsToday);
+
+      // Act
+      final result =
+          await IndoorRoutingService.getProximalCalendarEventLocation(
+              mockBuilding);
+
+      // Assert
+      expect(result, isNull);
+    });
+  });
+
+  group('LocationService Tests', () {
+    setUp(() {
+      IndoorRoutingService.mapService = mockMapService;
+      IndoorRoutingService.calendarRepository = mockCalendarRepository;
+    });
+
+    test('returns calendar location if geolocation is ConcordiaBuilding',
+        () async {
+      when(mockMapService.isLocationServiceEnabled())
+          .thenAnswer((_) async => true);
+      when(mockMapService.checkAndRequestLocationPermission())
+          .thenAnswer((_) async => true);
+
+      testPosition = Position(
+          longitude: -73.578,
+          latitude: 45.495,
+          timestamp: DateTime.now(),
+          accuracy: 30.0,
+          altitude: 20.0,
+          heading: 120,
+          speed: 150.9,
+          speedAccuracy: 10.0,
+          altitudeAccuracy: 10.0,
+          headingAccuracy: 10.0);
+
+      // Act
+      final result = await IndoorRoutingService.getCurrentClassroom();
+
+      // Assert
+      expect(result?.lat, testPosition.latitude);
+      expect(result?.lng, testPosition.longitude);
+    });
+
+    test('returns calendar location if geolocation is not ConcordiaBuilding',
+        () async {
+      when(mockMapService.isLocationServiceEnabled())
+          .thenAnswer((_) async => true);
+      when(mockMapService.checkAndRequestLocationPermission())
+          .thenAnswer((_) async => true);
+
+      // Arrange
+      const mockCalendarLocation = Location(
+        45.4971,
+        -73.5788,
+        'Room 101',
+        null,
+        null,
+        null,
+        null,
+      );
+
+      // Act
+      final result = await IndoorRoutingService.getCurrentClassroom();
+
+      // Assert
+      expect(result?.lat, testPosition.latitude);
+      expect(result?.lng, testPosition.longitude);
+    });
+  });
   group('getIndoorRoute', () {
     // Create BuildingData for test building H
     const buildingH = BuildingRepository.h;
@@ -73,7 +291,7 @@ void main() async {
         outdoorExitPoint: ConcordiaFloorPoint(floorH1, 5, 5));
 
     test('should return no route if origin and destination are the same', () {
-      final origin = ConcordiaFloorPoint(floorH1, 0, 0);
+      final origin = ConcordiaFloorPoint(floorH1, 310, 940);
       final destination = origin;
 
       final route = IndoorRoutingService.getIndoorRoute(
@@ -86,7 +304,7 @@ void main() async {
     test(
         'should return route when origin and destination are in different buildings',
         () {
-      final origin = ConcordiaFloorPoint(floorH1, 0, 0);
+      final origin = ConcordiaFloorPoint(floorH1, 310, 940);
       final destination = ConcordiaFloorPoint(floorER8, 0, 0);
 
       final route = IndoorRoutingService.getIndoorRoute(
@@ -126,147 +344,84 @@ void main() async {
     });
   });
 
-  group('IndoorRoutingService', () {
-    test('should return null when Geolocator throws an exception', () async {
-      // Arrange
-      final mockGeolocator = MockGeolocatorPlatform();
-      when(mockGeolocator.getCurrentPosition(
-        locationSettings: anyNamed('locationSettings'),
-      )).thenThrow(Exception());
-
-      // Act
-      final result = await IndoorRoutingService.getRoundedGeolocation();
-
-      // Assert
-      expect(result, isNull);
+  group("Test Location without channel", () {
+    test('returns null when accuracy > 50', () async {
+      // position with accuracy > 50
+      testPosition = Position(
+          longitude: -73.5788992164221,
+          latitude: 45.4952628500172,
+          timestamp: DateTime.now(),
+          accuracy: 70.0,
+          altitude: 20.0,
+          heading: 120,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+          altitudeAccuracy: 0.0,
+          headingAccuracy: 0.0);
+      final res = await IndoorRoutingService.getRoundedGeolocation();
+      expect(res, null); // should return null
     });
   });
 
-  group('test indoor routing service', () {
-    // random position far away from campuses
-    var testPosition = Position(
-        longitude: 100.0,
-        latitude: 100.0,
-        timestamp: DateTime.now(),
-        accuracy: 30.0,
-        altitude: 20.0,
-        heading: 120,
-        speed: 150.9,
-        speedAccuracy: 10.0,
-        altitudeAccuracy: 10.0,
-        headingAccuracy: 10.0);
-    // ref to permission integers: https://github.com/Baseflow/flutter-geolocator/blob/main/geolocator_platform_interface/lib/src/extensions/integer_extensions.dart
-    var permission = 3; // permission set to accept
-    const request = 3; // request permission set to accept
-    var service = true; // locationService set to true
+  group("Test Location", () {
+    test('return current location when located far from campuses', () async {
+      final res = await IndoorRoutingService.getRoundedGeolocation();
 
-    // ensure plugin is initialized
-    TestWidgetsFlutterBinding.ensureInitialized();
-    const MethodChannel locationChannel =
-        MethodChannel('flutter.baseflow.com/geolocator');
+      testPosition = Position(
+          longitude: 100.0,
+          latitude: 100.0,
+          timestamp: DateTime.now(),
+          accuracy: 30.0,
+          altitude: 20.0,
+          heading: 120,
+          speed: 150.9,
+          speedAccuracy: 10.0,
+          altitudeAccuracy: 10.0,
+          headingAccuracy: 10.0);
 
-    Future locationHandler(MethodCall methodCall) async {
-      // grants access to location permissions
-      if (methodCall.method == 'requestPermission') {
-        return request;
-      }
-      // return testPosition when searching for the current location
-      if (methodCall.method == 'getCurrentPosition') {
-        return testPosition.toJson();
-      }
-      // set to true when device tries to check for permissions
-      if (methodCall.method == 'isLocationServiceEnabled') {
-        return service;
-      }
-      // returns authorized when checking for location permissions
-      if (methodCall.method == 'checkPermission') {
-        return permission;
-      }
-    }
+      expect(res, isA<Location>());
+      expect(res?.lat, 100.0);
+      expect(res?.name, "Current Location");
+    });
 
-    group("Test Location", () {
-      setUpAll(() {
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(locationChannel, locationHandler);
-      });
+    test('return concordia building located in', () async {
+      // position in JMSB
+      testPosition = Position(
+          longitude: -73.5788992164221,
+          latitude: 45.4952628500172,
+          timestamp: DateTime.now(),
+          accuracy: 10.0,
+          altitude: 20.0,
+          heading: 120,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+          altitudeAccuracy: 0.0,
+          headingAccuracy: 0.0);
+      final res = await IndoorRoutingService.getRoundedGeolocation();
+      // should return MB building
+      expect(res, isA<ConcordiaBuilding>());
+      expect(res?.lat, BuildingRepository.mb.lat);
+      expect(res?.name, "John Molson School of Business");
+    });
 
-      test('return current location when located far from campuses', () async {
-        final res = await IndoorRoutingService.getRoundedGeolocation();
-
-        expect(res, isA<Location>());
-        expect(res?.lat, 100.0);
-        expect(res?.name, "Current Location");
-      });
-
-      test('return concordia building located in', () async {
-        // position in JMSB
-        testPosition = Position(
-            longitude: -73.5788992164221,
-            latitude: 45.4952628500172,
-            timestamp: DateTime.now(),
-            accuracy: 10.0,
-            altitude: 20.0,
-            heading: 120,
-            speed: 0.0,
-            speedAccuracy: 0.0,
-            altitudeAccuracy: 0.0,
-            headingAccuracy: 0.0);
-        final res = await IndoorRoutingService.getRoundedGeolocation();
-        // should return MB building
-        expect(res, isA<ConcordiaBuilding>());
-        expect(res?.lat, BuildingRepository.mb.lat);
-        expect(res?.name, "John Molson School of Business");
-      });
-
-      test('return concordia building located in', () async {
-        // position in JMSB
-        testPosition = Position(
-            longitude: -73.64149708911341,
-            latitude: 45.45813042163085,
-            timestamp: DateTime.now(),
-            accuracy: 10.0,
-            altitude: 20.0,
-            heading: 120,
-            speed: 0.0,
-            speedAccuracy: 0.0,
-            altitudeAccuracy: 0.0,
-            headingAccuracy: 0.0);
-        final res = await IndoorRoutingService.getRoundedGeolocation();
-        // should return SP building
-        expect(res, isA<ConcordiaBuilding>());
-        expect(res?.lng, BuildingRepository.sp.lng);
-        expect(res?.name, "Richard J. Renaud Science Complex");
-      });
-
-      test('returns null when accuracy > 50', () async {
-        // position with accuracy > 50
-        testPosition = Position(
-            longitude: -73.5788992164221,
-            latitude: 45.4952628500172,
-            timestamp: DateTime.now(),
-            accuracy: 70.0,
-            altitude: 20.0,
-            heading: 120,
-            speed: 0.0,
-            speedAccuracy: 0.0,
-            altitudeAccuracy: 0.0,
-            headingAccuracy: 0.0);
-        final res = await IndoorRoutingService.getRoundedGeolocation();
-        expect(res, null); // should return null
-      });
-
-      test('returns null when service disabled', () async {
-        service = false;
-        final res = await IndoorRoutingService.getRoundedGeolocation();
-        expect(res, null); // should return null
-      });
-
-      test('returns error message if service disabled', () async {
-        service = true;
-        permission = 1;
-        final res = await IndoorRoutingService.getRoundedGeolocation();
-        expect(res, null);
-      });
+    test('return concordia building located in', () async {
+      // position in JMSB
+      testPosition = Position(
+          longitude: -73.64149708911341,
+          latitude: 45.45813042163085,
+          timestamp: DateTime.now(),
+          accuracy: 10.0,
+          altitude: 20.0,
+          heading: 120,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+          altitudeAccuracy: 0.0,
+          headingAccuracy: 0.0);
+      final res = await IndoorRoutingService.getRoundedGeolocation();
+      // should return SP building
+      expect(res, isA<ConcordiaBuilding>());
+      expect(res?.lng, BuildingRepository.sp.lng);
+      expect(res?.name, "Richard J. Renaud Science Complex");
     });
   });
 

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
@@ -134,7 +134,7 @@ void main() async {
     test('returns event location if there is an in-progress event', () async {
       // Arrange
       const mockBuilding = BuildingRepository.h;
-      var mockEventLocation = ConcordiaFloor("1", BuildingRepository.h);
+      final mockEventLocation = ConcordiaFloor("1", BuildingRepository.h);
       final now = DateTime.now();
       final eventsToday = [
         UserCalendarEvent(
@@ -217,17 +217,6 @@ void main() async {
           .thenAnswer((_) async => true);
       when(mockMapService.checkAndRequestLocationPermission())
           .thenAnswer((_) async => true);
-
-      // Arrange
-      const mockCalendarLocation = Location(
-        45.4971,
-        -73.5788,
-        'Room 101',
-        null,
-        null,
-        null,
-        null,
-      );
 
       // Act
       final result = await IndoorRoutingService.getCurrentClassroom();

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.dart
@@ -127,7 +127,7 @@ void main() async {
   });
 
   group('IndoorRoutingService', () {
-    test('should return null when Geolocator throws an exception', () async {
+    test('should return H building when Geolocator throws an exception', () async {
       // Arrange
       final mockGeolocator = MockGeolocatorPlatform();
       when(mockGeolocator.getCurrentPosition(
@@ -138,7 +138,7 @@ void main() async {
       final result = await IndoorRoutingService.getRoundedLocation();
 
       // Assert
-      expect(result, isNull);
+      expect(result, BuildingRepository.h);
     });
   });
 
@@ -238,7 +238,7 @@ void main() async {
         expect(res?.name, "Richard J. Renaud Science Complex");
       });
 
-      test('returns null when accuracy > 50', () async {
+      test('returns Hall building when accuracy > 50', () async {
         // position with accuracy > 50
         testPosition = Position(
             longitude: -73.5788992164221,
@@ -252,22 +252,20 @@ void main() async {
             altitudeAccuracy: 0.0,
             headingAccuracy: 0.0);
         final res = await IndoorRoutingService.getRoundedLocation();
-        expect(res, null); // should return null
+        expect(res, BuildingRepository.h);
       });
 
-      test('returns error message if service disabled', () async {
+      test('returns Hall building if service disabled', () async {
         service = false;
-        // should return an error
-        expect(IndoorRoutingService.getRoundedLocation(),
-            throwsA('Location services are disabled.'));
+        final res = await IndoorRoutingService.getRoundedLocation();
+        expect(res, BuildingRepository.h); 
       });
 
       test('returns error message if service disabled', () async {
         service = true;
         permission = 1;
-        // should return an error
-        expect(IndoorRoutingService.getRoundedLocation(),
-            throwsA('Location permissions are denied.'));
+        final res = await IndoorRoutingService.getRoundedLocation();
+        expect(res, BuildingRepository.h);
       });
     });
   });

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.mocks.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.mocks.dart
@@ -3,11 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
-import 'package:geolocator_platform_interface/src/enums/enums.dart' as _i5;
+import 'package:concordia_nav/data/repositories/calendar.dart' as _i7;
+import 'package:device_calendar/device_calendar.dart' as _i3;
+import 'package:geolocator_platform_interface/src/enums/enums.dart' as _i6;
 import 'package:geolocator_platform_interface/src/geolocator_platform_interface.dart'
-    as _i3;
+    as _i4;
 import 'package:geolocator_platform_interface/src/models/models.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 
@@ -30,64 +32,70 @@ class _FakePosition_0 extends _i1.SmartFake implements _i2.Position {
     : super(parent, parentInvocation);
 }
 
+class _FakeDeviceCalendarPlugin_1 extends _i1.SmartFake
+    implements _i3.DeviceCalendarPlugin {
+  _FakeDeviceCalendarPlugin_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [GeolocatorPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGeolocatorPlatform extends _i1.Mock
-    implements _i3.GeolocatorPlatform {
+    implements _i4.GeolocatorPlatform {
   MockGeolocatorPlatform() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<_i5.LocationPermission> checkPermission() =>
+  _i5.Future<_i6.LocationPermission> checkPermission() =>
       (super.noSuchMethod(
             Invocation.method(#checkPermission, []),
-            returnValue: _i4.Future<_i5.LocationPermission>.value(
-              _i5.LocationPermission.denied,
+            returnValue: _i5.Future<_i6.LocationPermission>.value(
+              _i6.LocationPermission.denied,
             ),
           )
-          as _i4.Future<_i5.LocationPermission>);
+          as _i5.Future<_i6.LocationPermission>);
 
   @override
-  _i4.Future<_i5.LocationPermission> requestPermission() =>
+  _i5.Future<_i6.LocationPermission> requestPermission() =>
       (super.noSuchMethod(
             Invocation.method(#requestPermission, []),
-            returnValue: _i4.Future<_i5.LocationPermission>.value(
-              _i5.LocationPermission.denied,
+            returnValue: _i5.Future<_i6.LocationPermission>.value(
+              _i6.LocationPermission.denied,
             ),
           )
-          as _i4.Future<_i5.LocationPermission>);
+          as _i5.Future<_i6.LocationPermission>);
 
   @override
-  _i4.Future<bool> isLocationServiceEnabled() =>
+  _i5.Future<bool> isLocationServiceEnabled() =>
       (super.noSuchMethod(
             Invocation.method(#isLocationServiceEnabled, []),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<_i2.Position?> getLastKnownPosition({
+  _i5.Future<_i2.Position?> getLastKnownPosition({
     bool? forceLocationManager = false,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getLastKnownPosition, [], {
               #forceLocationManager: forceLocationManager,
             }),
-            returnValue: _i4.Future<_i2.Position?>.value(),
+            returnValue: _i5.Future<_i2.Position?>.value(),
           )
-          as _i4.Future<_i2.Position?>);
+          as _i5.Future<_i2.Position?>);
 
   @override
-  _i4.Future<_i2.Position> getCurrentPosition({
+  _i5.Future<_i2.Position> getCurrentPosition({
     _i2.LocationSettings? locationSettings,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getCurrentPosition, [], {
               #locationSettings: locationSettings,
             }),
-            returnValue: _i4.Future<_i2.Position>.value(
+            returnValue: _i5.Future<_i2.Position>.value(
               _FakePosition_0(
                 this,
                 Invocation.method(#getCurrentPosition, [], {
@@ -96,67 +104,67 @@ class MockGeolocatorPlatform extends _i1.Mock
               ),
             ),
           )
-          as _i4.Future<_i2.Position>);
+          as _i5.Future<_i2.Position>);
 
   @override
-  _i4.Stream<_i5.ServiceStatus> getServiceStatusStream() =>
+  _i5.Stream<_i6.ServiceStatus> getServiceStatusStream() =>
       (super.noSuchMethod(
             Invocation.method(#getServiceStatusStream, []),
-            returnValue: _i4.Stream<_i5.ServiceStatus>.empty(),
+            returnValue: _i5.Stream<_i6.ServiceStatus>.empty(),
           )
-          as _i4.Stream<_i5.ServiceStatus>);
+          as _i5.Stream<_i6.ServiceStatus>);
 
   @override
-  _i4.Stream<_i2.Position> getPositionStream({
+  _i5.Stream<_i2.Position> getPositionStream({
     _i2.LocationSettings? locationSettings,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getPositionStream, [], {
               #locationSettings: locationSettings,
             }),
-            returnValue: _i4.Stream<_i2.Position>.empty(),
+            returnValue: _i5.Stream<_i2.Position>.empty(),
           )
-          as _i4.Stream<_i2.Position>);
+          as _i5.Stream<_i2.Position>);
 
   @override
-  _i4.Future<_i5.LocationAccuracyStatus> requestTemporaryFullAccuracy({
+  _i5.Future<_i6.LocationAccuracyStatus> requestTemporaryFullAccuracy({
     required String? purposeKey,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#requestTemporaryFullAccuracy, [], {
               #purposeKey: purposeKey,
             }),
-            returnValue: _i4.Future<_i5.LocationAccuracyStatus>.value(
-              _i5.LocationAccuracyStatus.reduced,
+            returnValue: _i5.Future<_i6.LocationAccuracyStatus>.value(
+              _i6.LocationAccuracyStatus.reduced,
             ),
           )
-          as _i4.Future<_i5.LocationAccuracyStatus>);
+          as _i5.Future<_i6.LocationAccuracyStatus>);
 
   @override
-  _i4.Future<_i5.LocationAccuracyStatus> getLocationAccuracy() =>
+  _i5.Future<_i6.LocationAccuracyStatus> getLocationAccuracy() =>
       (super.noSuchMethod(
             Invocation.method(#getLocationAccuracy, []),
-            returnValue: _i4.Future<_i5.LocationAccuracyStatus>.value(
-              _i5.LocationAccuracyStatus.reduced,
+            returnValue: _i5.Future<_i6.LocationAccuracyStatus>.value(
+              _i6.LocationAccuracyStatus.reduced,
             ),
           )
-          as _i4.Future<_i5.LocationAccuracyStatus>);
+          as _i5.Future<_i6.LocationAccuracyStatus>);
 
   @override
-  _i4.Future<bool> openAppSettings() =>
+  _i5.Future<bool> openAppSettings() =>
       (super.noSuchMethod(
             Invocation.method(#openAppSettings, []),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
-  _i4.Future<bool> openLocationSettings() =>
+  _i5.Future<bool> openLocationSettings() =>
       (super.noSuchMethod(
             Invocation.method(#openLocationSettings, []),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i5.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i5.Future<bool>);
 
   @override
   double distanceBetween(
@@ -193,4 +201,83 @@ class MockGeolocatorPlatform extends _i1.Mock
             returnValue: 0.0,
           )
           as double);
+}
+
+/// A class which mocks [CalendarRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCalendarRepository extends _i1.Mock
+    implements _i7.CalendarRepository {
+  MockCalendarRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i3.DeviceCalendarPlugin get plugin =>
+      (super.noSuchMethod(
+            Invocation.getter(#plugin),
+            returnValue: _FakeDeviceCalendarPlugin_1(
+              this,
+              Invocation.getter(#plugin),
+            ),
+          )
+          as _i3.DeviceCalendarPlugin);
+
+  @override
+  set plugin(_i3.DeviceCalendarPlugin? _plugin) => super.noSuchMethod(
+    Invocation.setter(#plugin, _plugin),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i5.Future<bool> checkPermissions() =>
+      (super.noSuchMethod(
+            Invocation.method(#checkPermissions, []),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i7.UserCalendar>> getUserCalendars() =>
+      (super.noSuchMethod(
+            Invocation.method(#getUserCalendars, []),
+            returnValue: _i5.Future<List<_i7.UserCalendar>>.value(
+              <_i7.UserCalendar>[],
+            ),
+          )
+          as _i5.Future<List<_i7.UserCalendar>>);
+
+  @override
+  _i5.Future<List<_i7.UserCalendarEvent>> getEvents(
+    List<_i7.UserCalendar>? selectedCalendars,
+    Duration? timeSpan,
+    DateTime? utcStart,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#getEvents, [
+              selectedCalendars,
+              timeSpan,
+              utcStart,
+            ]),
+            returnValue: _i5.Future<List<_i7.UserCalendarEvent>>.value(
+              <_i7.UserCalendarEvent>[],
+            ),
+          )
+          as _i5.Future<List<_i7.UserCalendarEvent>>);
+
+  @override
+  _i5.Future<List<_i7.UserCalendarEvent>> getEventsOnLocalDate(
+    List<_i7.UserCalendar>? selectedCalendars,
+    int? offset,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#getEventsOnLocalDate, [
+              selectedCalendars,
+              offset,
+            ]),
+            returnValue: _i5.Future<List<_i7.UserCalendarEvent>>.value(
+              <_i7.UserCalendarEvent>[],
+            ),
+          )
+          as _i5.Future<List<_i7.UserCalendarEvent>>);
 }

--- a/concordia_nav/test/map/compact_location_test.mocks.dart
+++ b/concordia_nav/test/map/compact_location_test.mocks.dart
@@ -359,24 +359,6 @@ class MockMapViewModel extends _i1.Mock implements _i5.MapViewModel {
           as _i8.Future<bool>);
 
   @override
-  _i8.Future<void> zoomIn() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomIn, []),
-            returnValue: _i8.Future<void>.value(),
-            returnValueForMissingStub: _i8.Future<void>.value(),
-          )
-          as _i8.Future<void>);
-
-  @override
-  _i8.Future<void> zoomOut() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomOut, []),
-            returnValue: _i8.Future<void>.value(),
-            returnValueForMissingStub: _i8.Future<void>.value(),
-          )
-          as _i8.Future<void>);
-
-  @override
   double getDistance(_i4.LatLng? point1, _i4.LatLng? point2) =>
       (super.noSuchMethod(
             Invocation.method(#getDistance, [point1, point2]),

--- a/concordia_nav/test/map/map_service_test.mocks.dart
+++ b/concordia_nav/test/map/map_service_test.mocks.dart
@@ -268,24 +268,6 @@ class MockMapService extends _i1.Mock implements _i7.MapService {
           as _i5.Future<_i2.BitmapDescriptor>);
 
   @override
-  _i5.Future<void> zoomIn() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomIn, []),
-            returnValue: _i5.Future<void>.value(),
-            returnValueForMissingStub: _i5.Future<void>.value(),
-          )
-          as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> zoomOut() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomOut, []),
-            returnValue: _i5.Future<void>.value(),
-            returnValueForMissingStub: _i5.Future<void>.value(),
-          )
-          as _i5.Future<void>);
-
-  @override
   _i5.Future<bool> isLocationServiceEnabled() =>
       (super.noSuchMethod(
             Invocation.method(#isLocationServiceEnabled, []),

--- a/concordia_nav/test/map/map_viewmodel_test.mocks.dart
+++ b/concordia_nav/test/map/map_viewmodel_test.mocks.dart
@@ -163,24 +163,6 @@ class MockMapService extends _i1.Mock implements _i4.MapService {
           as _i10.Future<_i2.BitmapDescriptor>);
 
   @override
-  _i10.Future<void> zoomIn() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomIn, []),
-            returnValue: _i10.Future<void>.value(),
-            returnValueForMissingStub: _i10.Future<void>.value(),
-          )
-          as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> zoomOut() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomOut, []),
-            returnValue: _i10.Future<void>.value(),
-            returnValueForMissingStub: _i10.Future<void>.value(),
-          )
-          as _i10.Future<void>);
-
-  @override
   _i10.Future<bool> isLocationServiceEnabled() =>
       (super.noSuchMethod(
             Invocation.method(#isLocationServiceEnabled, []),
@@ -536,24 +518,6 @@ class MockMapViewModel extends _i1.Mock implements _i11.MapViewModel {
             returnValue: _i10.Future<bool>.value(false),
           )
           as _i10.Future<bool>);
-
-  @override
-  _i10.Future<void> zoomIn() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomIn, []),
-            returnValue: _i10.Future<void>.value(),
-            returnValueForMissingStub: _i10.Future<void>.value(),
-          )
-          as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> zoomOut() =>
-      (super.noSuchMethod(
-            Invocation.method(#zoomOut, []),
-            returnValue: _i10.Future<void>.value(),
-            returnValueForMissingStub: _i10.Future<void>.value(),
-          )
-          as _i10.Future<void>);
 
   @override
   double getDistance(_i2.LatLng? point1, _i2.LatLng? point2) =>


### PR DESCRIPTION
### 🛠 Proposed Changes:

- makes selectedCalendars nullable in CalendarRepository, if this is nulled, all calendars available on the device will be searched
- renames getRoundedLocation to getRoundedGeolocation for clarity (this method currently has no refs other than tests)
- changes getRoundedGeolocation behaviour to return null when loc disabled/etc. for consistency with the comments - tests updated
- adds method parseRoomNumber() - not yet tested but some test cases are suggested in the comments
- adds method getProximalCalendarEventLocation() which finds a location based on calendar events (either an ongoing event or failing that, a proximal event) (not yet tested)
- adds method getCurrentClassroom() which returns calendar event location (precise up to a room) if it agrees with geolocation. Else returns geolocation, or calendar event location if geo is unavailable.

**TODO:** getProximalCalendarEventLocation currently searches all calendars. I don't know how the settings pane works where we will persist some state from the user of which calendars to use (I believe @Jpuntul is working on calendar UI in general)

**TODO:** edge case of calendar unavailable not tested

### 🔗 Related Issue(s):

- Resolves #294 
- relates to #288 but that's something that will need to be dealt with by Front (they are using Google Maps to get location at the moment)