### PR TITLE
Feature/OpenAI function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following variables can be configured:
 | Variable            | Description                       | Value                      |
 | ------------------- | --------------------------------- | -------------------------- |
 | GOOGLE_MAPS_API_KEY | Used to integrate Google Maps API | `YOUR_GOOGLE_MAPS_API_KEY` |
+| OPENAI_API_KEY      | Used to integrate OpenAI API      | `YOUR_OPENAI_API_KEY`      |
 
 ## Generating RPS Scripts
 

--- a/concordia_nav/lib/data/domain-model/travelling_salesman_request.dart
+++ b/concordia_nav/lib/data/domain-model/travelling_salesman_request.dart
@@ -1,0 +1,22 @@
+import 'location.dart';
+
+class TravellingSalesmanRequest {
+  /// A list of Locations to visited and how many seconds need to be spent there, that
+  /// do not need to be visited in any particular order. The string must be unique
+  /// across all todoLocations and events in the route and can be used to identify the
+  /// location in the response.
+  List<(String, Location, int)> todoLocations;
+
+  /// A list of events that need to be attended at fixed *local* times. Todo items will
+  /// be fit between any gaps.
+  List<(String, Location, DateTime, DateTime)> events;
+
+  /// A *local* start time for the route.
+  DateTime startTime;
+
+  /// Start location for the route
+  Location startLocation;
+
+  TravellingSalesmanRequest(
+      this.todoLocations, this.events, this.startTime, this.startLocation);
+}

--- a/concordia_nav/lib/data/repositories/building_repository.dart
+++ b/concordia_nav/lib/data/repositories/building_repository.dart
@@ -223,6 +223,26 @@ class BuildingRepository {
     (BuildingRepository.hu.abbreviation): hu,
   };
 
+  static Map<String, ConcordiaBuilding> buildingByName = {
+    (BuildingRepository.h.name): h,
+    (BuildingRepository.lb.name): lb,
+    (BuildingRepository.er.name): er,
+    (BuildingRepository.ls.name): ls,
+    (BuildingRepository.gm.name): gm,
+    (BuildingRepository.ev.name): ev,
+    (BuildingRepository.mb.name): mb,
+    (BuildingRepository.fb.name): fb,
+    (BuildingRepository.fg.name): fg,
+    (BuildingRepository.cl.name): cl,
+    (BuildingRepository.vl.name): vl,
+    (BuildingRepository.fc.name): fc,
+    (BuildingRepository.ad.name): ad,
+    (BuildingRepository.cj.name): cj,
+    (BuildingRepository.sp.name): sp,
+    (BuildingRepository.cc.name): cc,
+    (BuildingRepository.hu.name): hu,
+  };
+
   /// Helper method to load polygons and label positions from a specified path.
   static Future<Map<String, dynamic>> _loadPolygonsAndLabels(
       String path) async {

--- a/concordia_nav/lib/data/repositories/places_repository.dart
+++ b/concordia_nav/lib/data/repositories/places_repository.dart
@@ -2,6 +2,28 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../services/places_service.dart';
 import '../domain-model/place.dart';
 
+class TextSearchParams {
+  final String query;
+  final LatLng location;
+  final double radius;
+  final PlaceType? type;
+  final bool openNow;
+  final int pageSize;
+  final String? languageCode;
+  final String? regionCode;
+
+  TextSearchParams({
+    required this.query,
+    required this.location,
+    this.radius = 1500,
+    this.type,
+    this.openNow = false,
+    this.pageSize = 10,
+    this.languageCode,
+    this.regionCode,
+  });
+}
+
 class PlacesRepository {
   final PlacesService _service;
 
@@ -34,25 +56,18 @@ class PlacesRepository {
   /// Wraps PlacesService.textSearch to retrieve a List of [Place] objects via
   /// the Places API.
   Future<List<Place>> textSearchPlaces({
-    required String query,
-    required LatLng location,
-    double radius = 1500,
-    PlaceType? type,
-    bool openNow = false,
-    int pageSize = 10,
-    String? languageCode,
-    String? regionCode,
+    required TextSearchParams params,
   }) async {
     try {
       return await _service.textSearch(
-        textQuery: query,
-        location: location,
-        includedType: type,
-        radius: radius,
-        openNow: openNow,
-        pageSize: pageSize,
-        languageCode: languageCode,
-        regionCode: regionCode,
+        textQuery: params.query,
+        location: params.location,
+        includedType: params.type,
+        radius: params.radius,
+        openNow: params.openNow,
+        pageSize: params.pageSize,
+        languageCode: params.languageCode,
+        regionCode: params.regionCode,
       );
     } catch (e) {
       throw Exception('Failed to fetch text search places: $e');

--- a/concordia_nav/lib/data/repositories/places_repository.dart
+++ b/concordia_nav/lib/data/repositories/places_repository.dart
@@ -1,35 +1,33 @@
-// TODO: Currently not used. If needed, update the imports and the class to use the PlacesService. If not needed, delete this file.
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import '../services/places_service.dart';
+import '../domain-model/place.dart';
 
-// import 'package:google_maps_flutter/google_maps_flutter.dart';
-// import '../services/places_service.dart';
-// import '../domain-model/place.dart';
+class PlacesRepository {
+  final PlacesService _service;
 
-// class PlacesRepository {
-//   final PlacesService _service;
+  PlacesRepository(this._service);
 
-//   PlacesRepository(this._service);
-
-//   /// Fetches nearby places using the Places API.
-//   Future<List<Place>> getNearbyPlaces({
-//     required LatLng location,
-//     required double radius,
-//     required PlaceType? type,
-//     int maxResultCount = 10,
-//     String? languageCode,
-//     String? regionCode,
-//     List<String>? fields,
-//   }) async {
-//     try {
-//       return await _service.nearbySearch(
-//         location: location,
-//         radius: radius,
-//         includedType: type,
-//         maxResultCount: maxResultCount,
-//         languageCode: languageCode,
-//         regionCode: regionCode,
-//       );
-//     } catch (e) {
-//       throw Exception('Failed to fetch nearby places: $e');
-//     }
-//   }
-// }
+  /// Fetches nearby places using the Places API.
+  Future<List<Place>> getNearbyPlaces({
+    required LatLng location,
+    required double radius,
+    required PlaceType? type,
+    int maxResultCount = 10,
+    String? languageCode,
+    String? regionCode,
+    List<String>? fields,
+  }) async {
+    try {
+      return await _service.nearbySearch(
+        location: location,
+        radius: radius,
+        includedType: type,
+        maxResultCount: maxResultCount,
+        languageCode: languageCode,
+        regionCode: regionCode,
+      );
+    } catch (e) {
+      throw Exception('Failed to fetch nearby places: $e');
+    }
+  }
+}

--- a/concordia_nav/lib/data/repositories/places_repository.dart
+++ b/concordia_nav/lib/data/repositories/places_repository.dart
@@ -30,4 +30,32 @@ class PlacesRepository {
       throw Exception('Failed to fetch nearby places: $e');
     }
   }
+
+  /// Wraps PlacesService.textSearch to retrieve a List of [Place] objects via
+  /// the Places API.
+  Future<List<Place>> textSearchPlaces({
+    required String query,
+    required LatLng location,
+    double radius = 1500,
+    PlaceType? type,
+    bool openNow = false,
+    int pageSize = 10,
+    String? languageCode,
+    String? regionCode,
+  }) async {
+    try {
+      return await _service.textSearch(
+        textQuery: query,
+        location: location,
+        includedType: type,
+        radius: radius,
+        openNow: openNow,
+        pageSize: pageSize,
+        languageCode: languageCode,
+        regionCode: regionCode,
+      );
+    } catch (e) {
+      throw Exception('Failed to fetch text search places: $e');
+    }
+  }
 }

--- a/concordia_nav/lib/data/services/helpers/smart_planner_helpers.dart
+++ b/concordia_nav/lib/data/services/helpers/smart_planner_helpers.dart
@@ -1,13 +1,14 @@
-import 'dart:developer' as dev;
 import '../../domain-model/location.dart';
+import '../../domain-model/place.dart';
 
 /// Generates a UUID based on [base] by appending a counter suffix if needed.
 String generateUniqueId(String base, Set<String> usedIds) {
-  String id = base;
-  int counter = 1;
+  var id = base;
+  var i = 1;
   while (usedIds.contains(id)) {
-    id = "${base}_$counter";
-    counter++;
+    // ignore: unnecessary_string_escapes
+    id = '$base\_$i';
+    i++;
   }
   usedIds.add(id);
   return id;
@@ -16,16 +17,13 @@ String generateUniqueId(String base, Set<String> usedIds) {
 /// Rebases [parsedTime] onto the day of [planDay].
 /// Returns a new DateTime with the year, month, and day from [planDay] and the
 /// time from [parsedTime].
-DateTime rebaseTime(DateTime parsedTime, DateTime planDay) {
-  return DateTime(
+DateTime rebaseTime(DateTime parsedTime, DateTime planDay) => DateTime(
     planDay.year,
     planDay.month,
     planDay.day,
     parsedTime.hour,
     parsedTime.minute,
-    parsedTime.second,
-  );
-}
+    parsedTime.second);
 
 /// Validates and filters a list of events so that:
 /// - Each event is on the same day as [planDay],
@@ -33,28 +31,68 @@ DateTime rebaseTime(DateTime parsedTime, DateTime planDay) {
 /// - And events do not overlap (i.e. each event starts at or after the previous
 ///  event ends).
 List<(String, Location, DateTime, DateTime)> validateEvents(
-  List<(String, Location, DateTime, DateTime)> events,
-  DateTime planDay,
-) {
-  final List<(String, Location, DateTime, DateTime)> validEvents = [];
+    List<(String, Location, DateTime, DateTime)> events, DateTime planDay) {
   events.sort((a, b) => a.$3.compareTo(b.$3));
+  final valid = <(String, Location, DateTime, DateTime)>[];
   DateTime? lastEnd;
-  for (var event in events) {
-    final eventStart = event.$3;
-    final eventEnd = event.$4;
-    final eventDay =
-        DateTime(eventStart.year, eventStart.month, eventStart.day);
-    if (eventDay != planDay) {
-      dev.log(
-          "Event ${event.$1} is not on the same day as the plan: skipping.");
-      continue;
-    }
-    if (lastEnd != null && eventStart.isBefore(lastEnd)) {
-      dev.log("Event ${event.$1} overlaps with previous event: skipping.");
-      continue;
-    }
-    validEvents.add(event);
-    lastEnd = eventEnd;
+  for (var e in events) {
+    if (DateTime(e.$3.year, e.$3.month, e.$3.day) != planDay) continue;
+    if (lastEnd != null && e.$3.isBefore(lastEnd)) continue;
+    valid.add(e);
+    lastEnd = e.$4;
   }
-  return validEvents;
+  return valid;
+}
+
+/// Parses a [Place] object's' attributes to create a valid [Location] object.
+Location parseLocationFromPlace(Place place) {
+  // Based on the results shown in the Places API test screen we can do a split
+  // by commas.
+  // Ex. "5590 Rue Laurendeau, Montréal, QC H4E 3W3, Canada"
+  // -> ["5590 Rue Laurendeau", " Montréal", " QC H4E 3W3", " Canada"]
+  //
+  // We then parse to fill in streetAddress, city, province, postalCode.
+  // The final piece is usually the country, which we can be ignored.
+
+  String? streetAddress;
+  String? city;
+  String? province;
+  String? postalCode;
+
+  if (place.address != null) {
+    final rawParts = place.address!.split(',');
+    final parts = rawParts.map((s) => s.trim()).toList();
+    // where parts = ["5590 Rue Laurendeau", "Montréal", "QC H4E 3W3", "Canada"]
+
+    if (parts.isNotEmpty) {
+      streetAddress = parts[0]; // "5590 Rue Laurendeau"
+    }
+    if (parts.length > 1) {
+      city = parts[1]; // "Montréal"
+    }
+    if (parts.length > 2) {
+      // something like "QC H4E 3W3" can be further split on whitespace to
+      // separate province from postal code.
+      final provincePostal = parts[2].split(RegExp(r'\s+'));
+      // e.g. provincePostal = ["QC", "H4E", "3W3"]
+
+      if (provincePostal.isNotEmpty) {
+        province = provincePostal.first; // "QC"
+      }
+      if (provincePostal.length > 1) {
+        // The rest is the postal code. e.g. ["H4E", "3W3"] -> "H4E 3W3"
+        postalCode = provincePostal.sublist(1).join(' ');
+      }
+    }
+  }
+
+  return Location(
+    place.location.latitude,
+    place.location.longitude,
+    place.name,
+    streetAddress,
+    city,
+    province,
+    postalCode,
+  );
 }

--- a/concordia_nav/lib/data/services/helpers/smart_planner_helpers.dart
+++ b/concordia_nav/lib/data/services/helpers/smart_planner_helpers.dart
@@ -1,0 +1,60 @@
+import 'dart:developer' as dev;
+import '../../domain-model/location.dart';
+
+/// Generates a UUID based on [base] by appending a counter suffix if needed.
+String generateUniqueId(String base, Set<String> usedIds) {
+  String id = base;
+  int counter = 1;
+  while (usedIds.contains(id)) {
+    id = "${base}_$counter";
+    counter++;
+  }
+  usedIds.add(id);
+  return id;
+}
+
+/// Rebases [parsedTime] onto the day of [planDay].
+/// Returns a new DateTime with the year, month, and day from [planDay] and the
+/// time from [parsedTime].
+DateTime rebaseTime(DateTime parsedTime, DateTime planDay) {
+  return DateTime(
+    planDay.year,
+    planDay.month,
+    planDay.day,
+    parsedTime.hour,
+    parsedTime.minute,
+    parsedTime.second,
+  );
+}
+
+/// Validates and filters a list of events so that:
+/// - Each event is on the same day as [planDay],
+/// - Each event's start is before its end,
+/// - And events do not overlap (i.e. each event starts at or after the previous
+///  event ends).
+List<(String, Location, DateTime, DateTime)> validateEvents(
+  List<(String, Location, DateTime, DateTime)> events,
+  DateTime planDay,
+) {
+  final List<(String, Location, DateTime, DateTime)> validEvents = [];
+  events.sort((a, b) => a.$3.compareTo(b.$3));
+  DateTime? lastEnd;
+  for (var event in events) {
+    final eventStart = event.$3;
+    final eventEnd = event.$4;
+    final eventDay =
+        DateTime(eventStart.year, eventStart.month, eventStart.day);
+    if (eventDay != planDay) {
+      dev.log(
+          "Event ${event.$1} is not on the same day as the plan: skipping.");
+      continue;
+    }
+    if (lastEnd != null && eventStart.isBefore(lastEnd)) {
+      dev.log("Event ${event.$1} overlaps with previous event: skipping.");
+      continue;
+    }
+    validEvents.add(event);
+    lastEnd = eventEnd;
+  }
+  return validEvents;
+}

--- a/concordia_nav/lib/data/services/smart_planner_service.dart
+++ b/concordia_nav/lib/data/services/smart_planner_service.dart
@@ -1,0 +1,271 @@
+import 'dart:convert';
+import 'dart:developer' as dev;
+import 'package:dart_openai/dart_openai.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import '../domain-model/travelling_salesman_request.dart';
+import '../domain-model/location.dart';
+import '../repositories/places_repository.dart';
+import 'places_service.dart';
+import '../domain-model/place.dart';
+import '../domain-model/concordia_building.dart';
+import '../repositories/building_repository.dart';
+import '../repositories/building_data_manager.dart';
+import './helpers/smart_planner_helpers.dart';
+
+class SmartPlannerService {
+  final PlacesRepository _placesRepository;
+
+  SmartPlannerService()
+      : _placesRepository = PlacesRepository(PlacesService()) {
+    OpenAI.apiKey = dotenv.env['OPENAI_API_KEY']!;
+  }
+
+  /// Attempts to interpret [name] as an indoor location reference.
+  /// If [name] has two or more tokens and the last token is numeric,
+  /// it will consider the first tokens as a building reference and the last
+  /// token as a room number. If a matching ConcordiaRoom is found via
+  /// BuildingDataManager, returns that room.
+  Future<Location?> _lookupIndoorLocation(String name) async {
+    final tokens = name.trim().split(RegExp(r'\s+'));
+    if (tokens.length >= 2) {
+      final potentialRoomNumber = tokens.last;
+      if (double.tryParse(potentialRoomNumber) != null) {
+        final buildingReference =
+            tokens.sublist(0, tokens.length - 1).join(" ");
+        ConcordiaBuilding? building;
+        // Try by abbreviation.
+        building = BuildingRepository
+            .buildingByAbbreviation[buildingReference.toUpperCase()];
+        if (building == null) {
+          for (var b in BuildingRepository.buildingByAbbreviation.values) {
+            if (b.name
+                .toLowerCase()
+                .contains(buildingReference.toLowerCase())) {
+              building = b;
+              break;
+            }
+          }
+        }
+        if (building != null) {
+          final buildingData =
+              await BuildingDataManager.getBuildingData(building.abbreviation);
+          if (buildingData != null) {
+            for (var roomList in buildingData.roomsByFloor.values) {
+              for (var room in roomList) {
+                if (room.roomNumber.trim() == potentialRoomNumber.trim()) {
+                  dev.log(
+                      "Found ConcordiaRoom for '$name': ${room.roomNumber} in ${building.name}");
+                  return room;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Attempts to find a matching place from our catalogs.
+  /// It first checks the indoor catalog, then outdoor ConcordiaBuildings,
+  /// then outdoor Places via Google Places.
+  /// If no matching location was found, it throws an error.
+  Future<Location> getLocationByName(String name) async {
+    // Indoor lookup is performed first.
+    final indoorResult = await _lookupIndoorLocation(name);
+    if (indoorResult != null) {
+      dev.log("Found ConcordiaFloor for '$name': ${indoorResult.name}");
+      return indoorResult;
+    }
+
+    // Next we'll try to check if the location corresponds to a ConU Building.
+    for (var building in BuildingRepository.buildingByAbbreviation.values) {
+      if (building.name.toLowerCase().contains(name.toLowerCase())) {
+        dev.log("Found ConcordiaBuilding for '$name': ${building.name}");
+        return building;
+      }
+    }
+
+    // Then we'll try outdoor places. To save on real-time calls to the Google
+    // Places API, we can hard-code a midpoint between both SGW and LOY, which
+    // encompasses a large-enough radius to cover a variety of places.
+    const midpointForCampuses = LatLng(45.47800, -73.60885);
+    try {
+      final List<Place> nearbyPlaces = await _placesRepository.getNearbyPlaces(
+        location: midpointForCampuses,
+        radius: 6000, // hopefully enough to capture most places
+        type: null,
+      );
+      final index = nearbyPlaces.indexWhere(
+        (place) => place.name.toLowerCase().contains(name.toLowerCase()),
+      );
+      if (index != -1) {
+        final match = nearbyPlaces[index];
+        dev.log("Found matching outdoor place for '$name': ${match.name}");
+        return Location(
+          match.location.latitude,
+          match.location.longitude,
+          match.name,
+          match.address,
+          null,
+          null,
+          null,
+        );
+      }
+    } on Error catch (e, stackTrace) {
+      dev.log("Error fetching nearby places: $e", stackTrace: stackTrace);
+    }
+
+    // At this point if no match is found, then the input was probably invalid.
+    dev.log("No location found for '$name'.");
+    throw Exception(
+        "No matching location found for '$name'. Please verify the name and try again.");
+  }
+
+  /// Returns a [TravellingSalesmanRequest] with lists for events and
+  /// todoLocations, along with the provided start time and start location.
+  Future<TravellingSalesmanRequest> generatePlannerData({
+    required String prompt,
+    required DateTime startTime,
+    required Location startLocation,
+  }) async {
+    // functions and function_call have been deprecated since v4.1.3 of the
+    // dart_openai package, so we instead opt to just use tools. A single
+    // add_task function is what lets us add items to either the events List or
+    // the todoLocations List, with the help of OpenAI.
+    final addTaskTool = OpenAIToolModel(
+      type: "function",
+      function: OpenAIFunctionModel.withParameters(
+        name: "add_task",
+        parameters: [
+          OpenAIFunctionProperty.string(
+            name: "locationName",
+            description:
+                "Name of the location. Must be unique across all todoLocations and events in the OpenAI response.",
+          ),
+          OpenAIFunctionProperty.string(
+            name: "startTime",
+            description:
+                "Event start time in ISO8601 format if provided, else empty",
+          ),
+          OpenAIFunctionProperty.string(
+            name: "endTime",
+            description:
+                "Event end time in ISO8601 format if provided, else empty",
+          ),
+          OpenAIFunctionProperty.integer(
+            name: "duration",
+            description:
+                "Duration in seconds if provided (for free-time tasks), else 0",
+          ),
+        ],
+      ),
+    );
+
+    // The main idea of having a system message being passed in addition
+    // to what the user's trying to ask for is simple: give the LLM context,
+    // and (more importantly,) restrict its output to what we want.
+    final systemMessage = OpenAIChatCompletionChoiceMessageModel(
+      content: [
+        OpenAIChatCompletionChoiceMessageContentItemModel.text("""
+          You are a planning assistant. The user may provide times in natural language 
+          (e.g. "from 11:00 AM to 2:00 PM", "from 3 pm to 4 pm", "for 30 minutes"). 
+          Your job is to convert these times into either ISO8601 date/time or a duration in seconds.
+
+          - If the user specifies both a start time and an end time, fill in 'startTime' and 'endTime' (e.g. "2025-03-18T14:00:00" and "2025-03-18T15:00:00").
+          - If the user only provides a duration (e.g. "for 30 minutes"), fill in 'duration'.
+          - If the user provides no times at all, a start time with no end time, or an end time with no start time, throw an error and cancel the operation.
+          - Return only function calls to 'add_task'. No extra text.
+          """)
+      ],
+      role: OpenAIChatMessageRole.system,
+    );
+
+    final userMessage = OpenAIChatCompletionChoiceMessageModel(
+      content: [OpenAIChatCompletionChoiceMessageContentItemModel.text(prompt)],
+      role: OpenAIChatMessageRole.user,
+    );
+
+    final chatResponse = await OpenAI.instance.chat.create(
+      // o1 could have been used here too, but 4o does the job. Based on newer
+      // models seeming to cost more credits, it's better to just use 4o.
+      model: "gpt-4o",
+      messages: [systemMessage, userMessage],
+      tools: [addTaskTool],
+    );
+
+    dev.log("Full Chat Response: ${chatResponse.toString()}");
+
+    final message = chatResponse.choices.first.message;
+    dev.log("Raw message: ${message.toString()}");
+
+    if (!message.haveToolCalls) {
+      dev.log("No tool calls detected. Message content: ${message.content}");
+      throw Exception("No function calls received from OpenAI.");
+    }
+
+    final List<(String, Location, DateTime, DateTime)> events = [];
+    final List<(String, Location, int)> todoLocations = [];
+
+    // The entire plan should take place in the same day.
+    final planDay = DateTime(startTime.year, startTime.month, startTime.day);
+
+    // As per the TravellingSalesmanRequest structure, we need to make sure that
+    // the string attribute stored in tuples is unique across all todoLocations
+    // and events in the route and can be used to properly identify the location
+    // in the response.
+    final Set<String> usedIds = {};
+
+    for (final toolCall in message.toolCalls!) {
+      final args = jsonDecode(toolCall.function.arguments);
+      final locationName = args["locationName"] as String? ?? "Plan Item";
+      final startStr = args["startTime"] as String? ?? "";
+      final endStr = args["endTime"] as String? ?? "";
+      final durationSec = args["duration"] as int? ?? 0;
+      final loc = await getLocationByName(locationName);
+
+      if (startStr.isNotEmpty && endStr.isNotEmpty) {
+        try {
+          final parsedStart = DateTime.parse(startStr);
+          final parsedEnd = DateTime.parse(endStr);
+          final startTimeParsed = rebaseTime(parsedStart, planDay);
+          final endTimeParsed = rebaseTime(parsedEnd, planDay);
+          if (!startTimeParsed.isBefore(endTimeParsed)) {
+            dev.log(
+                "Invalid event (start is not before end) for '$locationName': skipping.");
+            continue;
+          }
+          events.add((
+            generateUniqueId("add_event_$locationName", usedIds),
+            loc,
+            startTimeParsed,
+            endTimeParsed
+          ));
+        } on Error catch (e) {
+          dev.log("Error parsing times for event '$locationName': $e");
+        }
+      } else if (durationSec > 0) {
+        todoLocations.add((
+          generateUniqueId("add_location_$locationName", usedIds),
+          loc,
+          durationSec
+        ));
+      } else {
+        dev.log(
+            "No time info provided for '$locationName'. Cancelling operation.");
+        throw Exception(
+            "No time information provided for task '$locationName'. Please re-enter your prompt with proper time details.");
+      }
+    }
+
+    final validEvents = validateEvents(events, planDay);
+
+    return TravellingSalesmanRequest(
+      todoLocations,
+      validEvents,
+      startTime,
+      startLocation,
+    );
+  }
+}

--- a/concordia_nav/lib/data/services/smart_planner_service.dart
+++ b/concordia_nav/lib/data/services/smart_planner_service.dart
@@ -118,11 +118,17 @@ class SmartPlannerService {
     }
 
     // If for some reason there was no match from nearbySearch, use textSearch
-    final textResults = await _placesRepository.textSearchPlaces(
+    // Create TextSearchParams object with the appropriate parameters
+    final params = TextSearchParams(
       query: name,
       location: midpointForCampuses,
       radius: 15000, // Larger radius or tune as needed
     );
+
+// Use the params object when calling textSearchPlaces
+    final textResults =
+        await _placesRepository.textSearchPlaces(params: params);
+
     if (textResults.isNotEmpty) {
       final first = textResults.first;
       dev.log(

--- a/concordia_nav/lib/main.dart
+++ b/concordia_nav/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../data/domain-model/concordia_campus.dart';
 import 'data/domain-model/concordia_building.dart';
 import 'data/domain-model/location.dart';
+import 'data/domain-model/travelling_salesman_request.dart';
 import 'data/repositories/building_data_manager.dart';
 import 'data/repositories/calendar.dart';
 import 'ui/campus_map/campus_map_view.dart';
@@ -91,7 +92,12 @@ class MyApp extends StatelessWidget {
           '/SearchView': (context) => const SearchView(),
           '/SelectBuilding': (context) => const BuildingSelection(),
           '/SmartPlannerView': (context) => const SmartPlannerView(),
-          '/GeneratedPlanView': (context) => const GeneratedPlanView(),
+          '/GeneratedPlanView': (context) {
+            final args = ModalRoute.of(context)!.settings.arguments
+                as Map<String, dynamic>;
+            return GeneratedPlanView(
+                plan: args['plan'] as TravellingSalesmanRequest);
+          },
           '/IndoorDirectionsView': (context) {
             final args = ModalRoute.of(context)!.settings.arguments
                 as Map<String, dynamic>;

--- a/concordia_nav/lib/ui/smart_planner/generated_plan_view.dart
+++ b/concordia_nav/lib/ui/smart_planner/generated_plan_view.dart
@@ -1,44 +1,108 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../data/domain-model/travelling_salesman_request.dart';
 import '../setting/common_app_bart.dart';
 
-class GeneratedPlanView extends StatefulWidget {
-  const GeneratedPlanView({super.key});
+class GeneratedPlanView extends StatelessWidget {
+  // Right now, the plan that's getting passed from the "Smart Planner" view
+  // to this view is unsorted. ListTile widgets are currently rendered based on
+  // the order they appear in the plan. TODO: use TSP logic to optimize plan
+  final TravellingSalesmanRequest plan;
 
-  @override
-  State<GeneratedPlanView> createState() => _GeneratedPlanViewState();
-}
+  const GeneratedPlanView({super.key, required this.plan});
 
-class _GeneratedPlanViewState extends State<GeneratedPlanView> {
   @override
   Widget build(BuildContext context) {
+    final timeFormat = DateFormat('h:mm a');
+
+    // Formats a duration from seconds to Xh Ym or Xm.
+    String formatDuration(int totalSeconds) {
+      final hours = totalSeconds ~/ 3600;
+      final remainder = totalSeconds % 3600;
+      final minutes = remainder ~/ 60;
+
+      if (hours > 0 && minutes > 0) {
+        return '${hours}h ${minutes}m';
+      } else if (hours > 0) {
+        return '${hours}h';
+      } else {
+        return '${minutes}m';
+      }
+    }
+
+    // Events and todoLocations will be merged into a single timeline list
+    final timelineItems = <Map<String, dynamic>>[];
+
+    for (final event in plan.events) {
+      timelineItems.add({
+        'type': 'event',
+        'data': event,
+      });
+    }
+
+    for (final todo in plan.todoLocations) {
+      timelineItems.add({
+        'type': 'todo',
+        'data': todo,
+      });
+    }
+
+    final tiles = timelineItems.map((item) {
+      if (item['type'] == 'event') {
+        final event = item['data'];
+        final location = event.$2;
+        final start = event.$3;
+        final end = event.$4;
+        return ListTile(
+          leading: const Icon(Icons.event),
+          title: Text("Event at ${location.name}"),
+          subtitle: Text(
+            "${timeFormat.format(start.toLocal())} - ${timeFormat.format(end.toLocal())}",
+          ),
+        );
+      } else if (item['type'] == 'todo') {
+        final todo = item['data'];
+        final location = todo.$2;
+        final durationSeconds = todo.$3;
+        return ListTile(
+          leading: const Icon(Icons.location_on),
+          title: Text("Free-time at ${location.name}"),
+          subtitle: Text("Duration: ${formatDuration(durationSeconds)}"),
+        );
+      } else {
+        return const SizedBox();
+      }
+    }).toList();
+
     return Scaffold(
-      appBar: const CommonAppBar(title: "Smart Planner"),
+      appBar: const CommonAppBar(title: "Generated Plan"),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        child: ListView(
           children: [
             const Text(
-              "Suggested plan:",
-              style: TextStyle(fontSize: 14),
+              "Suggested Plan:",
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
-            Expanded(
-              child: Container(
-                margin: const EdgeInsets.symmetric(vertical: 20),
-                padding: const EdgeInsets.all(10),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(10),
-                  boxShadow: const [
-                    BoxShadow(
-                      color: Colors.black,
-                      blurRadius: 0.5,
-                    ),
-                  ],
-                ),
+            const Divider(),
+            Container(
+              margin: const EdgeInsets.symmetric(vertical: 20),
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(10),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Colors.black,
+                    blurRadius: 0.5,
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: tiles,
               ),
             ),
-            const SizedBox(height: 90),
           ],
         ),
       ),

--- a/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
+++ b/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
@@ -205,7 +205,7 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const CommonAppBar(title: "Smart Planner"),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(20.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -234,6 +234,7 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
                 controller: _planController,
                 textAlignVertical: TextAlignVertical.top,
                 keyboardType: TextInputType.multiline,
+                maxLines: null,
                 cursorColor: const Color(0xFF962e42),
                 decoration: InputDecoration(
                   hintText: "Create new plan...",

--- a/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
+++ b/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
@@ -1,19 +1,19 @@
 import 'dart:developer' as dev;
-
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import '../../data/domain-model/concordia_building.dart';
 import '../../data/repositories/building_repository.dart';
+import '../../data/services/smart_planner_service.dart';
 import '../../utils/map_viewmodel.dart';
+import '../../data/domain-model/location.dart';
+import '../../data/domain-model/travelling_salesman_request.dart';
 import '../setting/common_app_bart.dart';
+import 'generated_plan_view.dart';
 
 class SmartPlannerView extends StatefulWidget {
   final MapViewModel? mapViewModel;
 
-  const SmartPlannerView({
-    super.key,
-    this.mapViewModel,
-  });
+  const SmartPlannerView({super.key, this.mapViewModel});
 
   @override
   State<SmartPlannerView> createState() => _SmartPlannerViewState();
@@ -21,6 +21,7 @@ class SmartPlannerView extends StatefulWidget {
 
 class _SmartPlannerViewState extends State<SmartPlannerView> {
   late final MapViewModel _mapViewModel;
+  late final SmartPlannerService _smartPlannerService;
   bool isFetchingNearestBuilding = false;
 
   final TextEditingController _planController = TextEditingController();
@@ -28,11 +29,15 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
   List<String> buildings = [];
   bool locationEnabled = false;
   bool useCurrentLocation = false;
+  bool _isLoading = false;
+  String? _errorMessage;
+  TravellingSalesmanRequest? _plannerRequest;
 
   @override
   void initState() {
     super.initState();
     _mapViewModel = widget.mapViewModel ?? MapViewModel();
+    _smartPlannerService = SmartPlannerService();
     buildings = BuildingRepository.buildingByAbbreviation.values
         .map((building) => building.name)
         .toList();
@@ -53,12 +58,11 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
   }
 
   Future<void> _checkLocationEnabled() async {
-    final isLocationEnabled = await _mapViewModel.checkLocationAccess();
+    final isEnabled = await _mapViewModel.checkLocationAccess();
     setState(() {
-      locationEnabled = isLocationEnabled;
+      locationEnabled = isEnabled;
     });
-
-    if (isLocationEnabled) {
+    if (isEnabled) {
       await _getNearestBuilding();
     }
   }
@@ -67,12 +71,10 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
     setState(() {
       isFetchingNearestBuilding = true;
     });
-
     try {
       final currentPosition = await Geolocator.getCurrentPosition();
       ConcordiaBuilding? nearestBuilding;
       double bestDistance = double.infinity;
-
       for (var building in BuildingRepository.buildingByAbbreviation.values) {
         final distance = Geolocator.distanceBetween(
           currentPosition.latitude,
@@ -85,7 +87,6 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
           bestDistance = distance;
         }
       }
-
       setState(() {
         if (nearestBuilding != null && bestDistance <= 1000) {
           _sourceController.text = nearestBuilding.name;
@@ -95,12 +96,107 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
           useCurrentLocation = true;
         }
       });
-    } on Exception catch (e, stackTrace) {
-      // Optionally handle any errors like permission denial here
+      dev.log("Nearest building determined: ${_sourceController.text}");
+    } on Error catch (e, stackTrace) {
       dev.log("Error getting location", error: e, stackTrace: stackTrace);
     } finally {
       setState(() {
         isFetchingNearestBuilding = false;
+      });
+    }
+  }
+
+  /// Send a request to generate a plan based on user inputs.
+  /// Handles geolocation, input parsing, and planner service call. Navigates
+  /// to the Generated Plan view on success, otherwise throws an error.
+  Future<void> _generatePlan() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    final startTime = DateTime.now();
+
+    final sourceText = _sourceController.text.trim();
+    Location startLocation;
+    final currentPosition = await Geolocator.getCurrentPosition();
+    if (sourceText.toLowerCase() == "your location") {
+      startLocation = Location(
+        currentPosition.latitude,
+        currentPosition.longitude,
+        sourceText,
+        null,
+        null,
+        null,
+        null,
+      );
+    } else {
+      final building = BuildingRepository.buildingByName[sourceText];
+      if (building != null) {
+        startLocation = building;
+      } else {
+        startLocation = Location(
+          currentPosition.latitude,
+          currentPosition.longitude,
+          sourceText,
+          null,
+          null,
+          null,
+          null,
+        );
+      }
+    }
+
+    dev.log("Start location runtime type: ${startLocation.runtimeType}");
+    if (startLocation is ConcordiaBuilding) {
+      dev.log("Start location is a ConcordiaBuilding: ${startLocation.name}");
+    } else {
+      dev.log("Start location is a plain Location: ${startLocation.name}");
+    }
+
+    try {
+      dev.log("Generating plan with prompt: ${_planController.text}");
+      _plannerRequest = await _smartPlannerService.generatePlannerData(
+        prompt: _planController.text,
+        startTime: startTime,
+        startLocation: startLocation,
+      );
+      if (!mounted) return;
+      dev.log(
+          "Plan generated with ${_plannerRequest!.events.length} events and ${_plannerRequest!.todoLocations.length} todoLocations");
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => GeneratedPlanView(plan: _plannerRequest!),
+        ),
+      );
+    } on Error catch (e) {
+      _errorMessage = e.toString();
+      dev.log("Error generating plan: $_errorMessage");
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _buildingSelector(BuildContext context) async {
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      builder: (context) => ListView.builder(
+        itemCount: buildings.length,
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text(buildings[index]),
+            onTap: () => Navigator.pop(context, buildings[index]),
+          );
+        },
+      ),
+    );
+
+    if (result != null) {
+      setState(() {
+        _sourceController.text = result;
+        useCurrentLocation = false;
       });
     }
   }
@@ -115,7 +211,8 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const Text(
-              "Optimize your campus route by minimizing walking time and outdoor exposure. Enter your tasks, get an efficient plan, and follow step-by-step directions.",
+              "Optimize your campus route by minimizing walking time and outdoor exposure. "
+              "Enter your tasks, get an efficient plan, and follow step-by-step directions.",
               style: TextStyle(fontSize: 14),
               textAlign: TextAlign.justify,
             ),
@@ -136,6 +233,9 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
               child: TextField(
                 controller: _planController,
                 textAlignVertical: TextAlignVertical.top,
+                keyboardType: TextInputType.multiline,
+                cursorColor: const Color(0xFF962e42),
+                maxLines: 2,
                 decoration: InputDecoration(
                   hintText: "Create new plan...",
                   hintStyle: TextStyle(color: Colors.grey[500], fontSize: 14),
@@ -151,10 +251,7 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
                   padding: EdgeInsets.only(left: 10.0),
                   child: Text(
                     "Source location",
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Colors.grey,
-                    ),
+                    style: TextStyle(fontSize: 12, color: Colors.grey),
                   ),
                 ),
                 GestureDetector(
@@ -236,7 +333,17 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
                     ),
                   )
                 else
-                  const SizedBox()
+                  const SizedBox(),
+                if (_errorMessage != null)
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(
+                      "Error: $_errorMessage",
+                      style: const TextStyle(color: Colors.red),
+                    ),
+                  ),
+                const SizedBox(height: 20),
+                _buildSmartPlannerGuide(context),
               ],
             ),
           ],
@@ -246,10 +353,9 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
         padding: const EdgeInsets.only(bottom: 20.0, right: 20.0),
         child: ElevatedButton(
           onPressed: _planController.text.isNotEmpty &&
-                  _sourceController.text.isNotEmpty
-              ? () {
-                  Navigator.pushNamed(context, '/GeneratedPlanView');
-                }
+                  _sourceController.text.isNotEmpty &&
+                  !_isLoading
+              ? _generatePlan
               : null,
           style: ElevatedButton.styleFrom(
             backgroundColor: Theme.of(context).primaryColor,
@@ -257,34 +363,68 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
                 const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
             minimumSize: const Size(150, 40),
           ),
-          child: const Text("Make Plan", style: TextStyle(color: Colors.white)),
+          child: _isLoading
+              ? const CircularProgressIndicator(color: Color(0xFF962e42))
+              : const Text("Make Plan", style: TextStyle(color: Colors.white)),
         ),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     );
   }
+}
 
-  Future<void> _buildingSelector(BuildContext context) async {
-    final result = await showModalBottomSheet<String>(
-      context: context,
-      builder: (context) => ListView.builder(
-        itemCount: buildings.length,
-        itemBuilder: (context, index) {
-          return ListTile(
-            title: Text(buildings[index]),
-            onTap: () => Navigator.pop(context, buildings[index]),
-          );
-        },
-      ),
-    );
-
-    if (result != null) {
-      setState(
-        () {
-          _sourceController.text = result;
-          useCurrentLocation = false;
-        },
-      );
-    }
-  }
+Widget _buildSmartPlannerGuide(BuildContext context) {
+  return Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(16),
+    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    decoration: BoxDecoration(
+      // ignore: deprecated_member_use
+      color: Theme.of(context).colorScheme.secondary.withOpacity(0.2),
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Smart Planner Input Guide',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).primaryColor,
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          '• For events, provide both a start and an end time (e.g. "from 10:00 am to 11:00 am").',
+          style: TextStyle(fontSize: 14),
+        ),
+        const Text(
+          '• For free-time tasks, please provide a duration (e.g. "for 30 minutes").',
+          style: TextStyle(fontSize: 14),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Indoor & Outdoor Locations:',
+          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+        ),
+        const Text(
+          ' • Enter the name and we’ll take care of the rest!',
+          style: TextStyle(fontSize: 13),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Example:',
+          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+        ),
+        const Text.rich(
+          TextSpan(
+            text:
+                'I have to attend a seminar at the J.W. McConnell Building from 9 am to 10 am, then grab lunch at a Grocery Store and stay around there from 12:00 pm to 12:30 pm, and at some point I want to workout at a Gym for an hour.',
+          ),
+          style: TextStyle(fontSize: 13),
+        ),
+      ],
+    ),
+  );
 }

--- a/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
+++ b/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
@@ -402,13 +402,8 @@ Widget _buildSmartPlannerGuide(BuildContext context) {
           '• For free-time tasks, please provide a duration (e.g. "for 30 minutes").',
           style: TextStyle(fontSize: 14),
         ),
-        const SizedBox(height: 8),
         const Text(
-          'Indoor & Outdoor Locations:',
-          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-        ),
-        const Text(
-          ' • Enter the name and we’ll take care of the rest!',
+          ' • For classrooms, make sure to add a "." between floor and room number (e.g. H 9.27).',
           style: TextStyle(fontSize: 13),
         ),
         const SizedBox(height: 8),
@@ -419,7 +414,7 @@ Widget _buildSmartPlannerGuide(BuildContext context) {
         const Text.rich(
           TextSpan(
             text:
-                'I have to attend a seminar at the J.W. McConnell Building from 9 am to 10 am, then grab lunch at a Grocery Store and stay around there from 12:00 pm to 12:30 pm, and at some point I want to workout at a Gym for an hour.',
+                'I have to attend a seminar at the J.W. McConnell Building from 9 am to 9:30 am, I have a lecture in H 9.27 from 10:00 am to 11:00 am, and go to a coffee shop for 30 minutes, and I also have to go to Hall Building for 20 minutes.',
           ),
           style: TextStyle(fontSize: 13),
         ),

--- a/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
+++ b/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
@@ -235,7 +235,6 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
                 textAlignVertical: TextAlignVertical.top,
                 keyboardType: TextInputType.multiline,
                 cursorColor: const Color(0xFF962e42),
-                maxLines: 2,
                 decoration: InputDecoration(
                   hintText: "Create new plan...",
                   hintStyle: TextStyle(color: Colors.grey[500], fontSize: 14),

--- a/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
+++ b/concordia_nav/lib/ui/smart_planner/smart_planner_view.dart
@@ -12,8 +12,10 @@ import 'generated_plan_view.dart';
 
 class SmartPlannerView extends StatefulWidget {
   final MapViewModel? mapViewModel;
+  final SmartPlannerService? smartPlannerService;
 
-  const SmartPlannerView({super.key, this.mapViewModel});
+  const SmartPlannerView(
+      {super.key, this.mapViewModel, this.smartPlannerService});
 
   @override
   State<SmartPlannerView> createState() => _SmartPlannerViewState();
@@ -37,7 +39,7 @@ class _SmartPlannerViewState extends State<SmartPlannerView> {
   void initState() {
     super.initState();
     _mapViewModel = widget.mapViewModel ?? MapViewModel();
-    _smartPlannerService = SmartPlannerService();
+    _smartPlannerService = widget.smartPlannerService ?? SmartPlannerService();
     buildings = BuildingRepository.buildingByAbbreviation.values
         .map((building) => building.name)
         .toList();

--- a/concordia_nav/lib/utils/smart_planner/smart_planner_viewmodel.dart
+++ b/concordia_nav/lib/utils/smart_planner/smart_planner_viewmodel.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+
+import '../../data/domain-model/location.dart';
+import '../../data/domain-model/travelling_salesman_request.dart';
+import '../../data/services/smart_planner_service.dart';
+
+class SmartPlannerViewModel extends ChangeNotifier {
+  final SmartPlannerService _service;
+  TravellingSalesmanRequest? _plannerRequest;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  SmartPlannerViewModel({SmartPlannerService? service})
+      : _service = service ?? SmartPlannerService();
+
+  TravellingSalesmanRequest? get plannerRequest => _plannerRequest;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+
+  /// Calls the service to generate planner data using the given natural
+  /// language prompt, start time, and start location. If, for any reason,
+  /// any of the three values are considered invalid, an error is thrown.
+  Future<void> generatePlan({
+    required String prompt,
+    required DateTime startTime,
+    required Location startLocation,
+  }) async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _plannerRequest = await _service.generatePlannerData(
+        prompt: prompt,
+        startTime: startTime,
+        startLocation: startLocation,
+      );
+    } on Error catch (e) {
+      _errorMessage = e.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/concordia_nav/pubspec.lock
+++ b/concordia_nav/pubspec.lock
@@ -34,18 +34,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -122,10 +122,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -138,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -154,10 +154,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -198,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_openai:
+    dependency: "direct main"
+    description:
+      name: dart_openai
+      sha256: "853bb57fed6a71c3ba0324af5cb40c16d196cf3aa55b91d244964ae4a241ccf1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   dart_style:
     dependency: transitive
     description:
@@ -246,14 +254,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  fetch_api:
+    dependency: transitive
+    description:
+      name: fetch_api
+      sha256: "97f46c25b480aad74f7cc2ad7ccba2c5c6f08d008e68f95c1077286ce243d0e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  fetch_client:
+    dependency: transitive
+    description:
+      name: fetch_client
+      sha256: "9666ee14536778474072245ed5cba07db81ae8eb5de3b7bf4a2d1e2c49696092"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
@@ -600,10 +624,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -648,10 +672,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -664,10 +688,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -728,10 +752,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -752,10 +776,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -776,10 +800,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.0.2"
   provider:
     dependency: "direct main"
     description:
@@ -885,10 +909,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   sprintf:
     dependency: transitive
     description:
@@ -901,18 +925,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -925,10 +949,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   sync_http:
     dependency: transitive
     description:
@@ -941,34 +965,34 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.5"
   test_cov_console:
     dependency: "direct dev"
     description:
@@ -1149,10 +1173,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1178,5 +1202,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.6.1 <4.0.0"
   flutter: ">=3.27.0"

--- a/concordia_nav/pubspec.lock
+++ b/concordia_nav/pubspec.lock
@@ -34,18 +34,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
@@ -122,10 +122,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -138,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -154,10 +154,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   fetch_api:
     dependency: transitive
     description:
@@ -274,10 +274,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -616,18 +616,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -672,10 +672,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -688,10 +688,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -752,10 +752,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -776,10 +776,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -800,10 +800,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   provider:
     dependency: "direct main"
     description:
@@ -909,10 +909,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -925,18 +925,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -949,10 +949,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   sync_http:
     dependency: transitive
     description:
@@ -965,34 +965,34 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.8"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.8"
   test_cov_console:
     dependency: "direct dev"
     description:
@@ -1133,10 +1133,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1173,10 +1173,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1202,5 +1202,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.1 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/concordia_nav/pubspec.yaml
+++ b/concordia_nav/pubspec.yaml
@@ -84,6 +84,7 @@ dependencies:
   calendar_view: ^1.4.0
   logger: ^2.5.0
   google_places_flutter: ^2.1.0
+  dart_openai: ^5.1.0
 
 dev_dependencies:
   flutter_test:

--- a/concordia_nav/test/building/building_repository_test.dart
+++ b/concordia_nav/test/building/building_repository_test.dart
@@ -101,5 +101,20 @@ void main() {
       expect(BuildingRepository.buildingByAbbreviation["EV"]?.campus,
           ConcordiaCampus.sgw);
     });
+
+    test('get building by its name', () {
+      // should get building by its name
+      expect(BuildingRepository.buildingByName["Central Building"],
+          BuildingRepository.cc);
+      expect(
+          BuildingRepository.buildingByName["John Molson School of Business"],
+          BuildingRepository.mb);
+
+      // can get attributes of buildings
+      expect(
+          BuildingRepository.buildingByName["EV Building"]?.abbreviation, "EV");
+      expect(BuildingRepository.buildingByName["EV Building"]?.campus,
+          ConcordiaCampus.sgw);
+    });
   });
 }

--- a/concordia_nav/test/smart_planner/generated_plan_view_test.dart
+++ b/concordia_nav/test/smart_planner/generated_plan_view_test.dart
@@ -1,31 +1,110 @@
+import 'package:concordia_nav/data/domain-model/location.dart';
+import 'package:concordia_nav/data/domain-model/travelling_salesman_request.dart';
 import 'package:concordia_nav/ui/smart_planner/generated_plan_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('GeneratedPlanView Tests', () {
-    testWidgets('renders GeneratedPlanView page with non constant key', (WidgetTester tester) async {{
-      await tester.pumpWidget(MaterialApp(
-        home: GeneratedPlanView(key: UniqueKey())
-      ));
-      await tester.pump();
+    testWidgets('renders GeneratedPlanView page with non constant key',
+        (WidgetTester tester) async {
+      {
+        final samplePlan = TravellingSalesmanRequest(
+          [
+            (
+              "Place A",
+              const Location(45.5017, -73.5673, "Place A", "Description",
+                  "Category", "Address", "Building Code"),
+              900
+            ),
+            (
+              "Place B",
+              const Location(45.5017, -73.5673, "Place A", "Description",
+                  "Category", "Address", "Building Code"),
+              1200
+            ),
+          ],
+          [
+            (
+              "Meeting",
+              const Location(45.5017, -73.5673, "Place A", "Description",
+                  "Category", "Address", "Building Code"),
+              DateTime(2025, 3, 24, 14, 0),
+              DateTime(2025, 3, 24, 15, 0)
+            )
+          ],
+          DateTime(2025, 3, 24, 9, 0),
+          const Location(45.5017, -73.5673, "Place A", "Description",
+              "Category", "Address", "Building Code"),
+        );
 
-      expect(find.text("Smart Planner"), findsOneWidget);
-    }});
-    
-    testWidgets('GeneratedPlanView page renders correctly', (WidgetTester tester) async {{
-      await tester.pumpWidget(const MaterialApp(
-        home: GeneratedPlanView()
-      ));
-      await tester.pump();
+        final routes = {
+          '/GeneratedPlanView': (context) {
+            return GeneratedPlanView(
+              plan: samplePlan,
+              key: UniqueKey(),
+            );
+          }
+        };
 
-      expect(find.text("Smart Planner"), findsOneWidget);
-      expect(find.text('Suggested plan:'), findsOneWidget);
+        // Build the HomePage widget
+        await tester.pumpWidget(MaterialApp(
+          initialRoute: '/GeneratedPlanView',
+          routes: routes,
+        ));
 
-      // Press the Get Directions button
-      expect(find.text('Get Directions'), findsOneWidget);
-      await tester.tap(find.text('Get Directions'));
-      await tester.pumpAndSettle();
-    }});
+        expect(find.text("Generated Plan"), findsOneWidget);
+      }
+    });
+
+    testWidgets('GeneratedPlanView page renders correctly',
+        (WidgetTester tester) async {
+      {
+        final samplePlan = TravellingSalesmanRequest(
+          [
+            (
+              "Place A",
+              const Location(45.5017, -73.5673, "Place A", "Description",
+                  "Category", "Address", "Building Code"),
+              900
+            ),
+            (
+              "Place B",
+              const Location(45.5017, -73.5673, "Place A", "Description",
+                  "Category", "Address", "Building Code"),
+              1200
+            ),
+          ],
+          [
+            (
+              "Meeting",
+              const Location(45.5017, -73.5673, "Place A", "Description",
+                  "Category", "Address", "Building Code"),
+              DateTime(2025, 3, 24, 14, 0),
+              DateTime(2025, 3, 24, 15, 0)
+            )
+          ],
+          DateTime(2025, 3, 24, 9, 0),
+          const Location(45.5017, -73.5673, "Place A", "Description",
+              "Category", "Address", "Building Code"),
+        );
+
+        final routes = {
+          '/GeneratedPlanView': (context) {
+            return GeneratedPlanView(
+              plan: samplePlan,
+            );
+          }
+        };
+
+        // Build the HomePage widget
+        await tester.pumpWidget(MaterialApp(
+          initialRoute: '/GeneratedPlanView',
+          routes: routes,
+        ));
+
+        expect(find.text("Generated Plan"), findsOneWidget);
+      }
+    });
   });
 }

--- a/concordia_nav/test/smart_planner/smart_planner_view_test.dart
+++ b/concordia_nav/test/smart_planner/smart_planner_view_test.dart
@@ -276,14 +276,19 @@ void main() {
 
       // Act
       try {
-        await repo.textSearchPlaces(
+        // Create TextSearchParams object with the required parameters
+        final params = TextSearchParams(
           query: query,
           location: location,
           radius: radius,
           type: type,
           openNow: openNow,
         );
+
+        // Call textSearchPlaces using the params object
+        await repo.textSearchPlaces(params: params);
       } catch (e) {
+        // Expect the exception to be of type Exception
         expect(e, isA<Exception>());
       }
     });

--- a/concordia_nav/test/smart_planner/smart_planner_view_test.dart
+++ b/concordia_nav/test/smart_planner/smart_planner_view_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_catches_without_on_clauses
+
 import 'dart:convert';
 
 import 'package:concordia_nav/data/domain-model/location.dart';

--- a/concordia_nav/test/smart_planner/smart_planner_view_test.dart
+++ b/concordia_nav/test/smart_planner/smart_planner_view_test.dart
@@ -20,7 +20,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
-import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import '../map/map_viewmodel_test.mocks.dart';
@@ -114,7 +113,6 @@ OpenAIChatCompletionModel mockChatResponse = OpenAIChatCompletionModel(
   ),
 );
 
-@GenerateMocks([OpenAI])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   dotenv.load(fileName: '.env');

--- a/concordia_nav/test/smart_planner/smart_planner_view_test.dart
+++ b/concordia_nav/test/smart_planner/smart_planner_view_test.dart
@@ -1,15 +1,118 @@
+import 'dart:convert';
+
+import 'package:concordia_nav/data/domain-model/location.dart';
+import 'package:concordia_nav/data/domain-model/place.dart';
+import 'package:concordia_nav/data/domain-model/travelling_salesman_request.dart';
+import 'package:concordia_nav/data/repositories/places_repository.dart';
+import 'package:concordia_nav/data/services/places_service.dart';
+import 'package:concordia_nav/data/services/smart_planner_service.dart';
 import 'package:concordia_nav/ui/home/homepage_view.dart';
 import 'package:concordia_nav/ui/smart_planner/generated_plan_view.dart';
 import 'package:concordia_nav/ui/smart_planner/smart_planner_view.dart';
+import 'package:dart_openai/dart_openai.dart';
+import 'package:dart_openai/src/core/models/chat/sub_models/choices/sub_models/sub_models/sub_models/response_function_call.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import '../map/map_viewmodel_test.mocks.dart';
 
+OpenAIChatCompletionModel mockChatResponse = OpenAIChatCompletionModel(
+  id: "mock-id",
+  created: DateTime.now(),
+  systemFingerprint: "mock-system-fingerprint",
+  choices: [
+    OpenAIChatCompletionChoiceModel(
+      index: 0,
+      message: OpenAIChatCompletionChoiceMessageModel(
+        role: OpenAIChatMessageRole.assistant,
+        content: null, // Function call responses typically have no text content
+        toolCalls: [
+          // Tool call for add_indoor_event
+          OpenAIResponseToolCall(
+            id: "tool-call-1",
+            type: "function_call",
+            function: OpenAIResponseFunction(
+              name: "add_indoor_event",
+              arguments: jsonEncode({
+                "building": "Hall Building",
+                "floor": "9",
+                "room": "27",
+                "startTime": "2025-03-23T10:00:00Z",
+                "endTime": "2025-03-23T11:00:00Z",
+              }),
+            ),
+          ),
+          // Tool call for add_indoor_location
+          OpenAIResponseToolCall(
+            id: "tool-call-2",
+            type: "function_call",
+            function: OpenAIResponseFunction(
+              name: "add_indoor_location",
+              arguments: jsonEncode({
+                "building": "Hall Building",
+                "floor": "9",
+                "room": "27",
+                "duration": 3600, // 1 hour
+              }),
+            ),
+          ),
+          // Tool call for add_outdoor_event
+          OpenAIResponseToolCall(
+            id: "tool-call-3",
+            type: "function_call",
+            function: OpenAIResponseFunction(
+              name: "add_outdoor_event",
+              arguments: jsonEncode({
+                "locationName": "Starbucks",
+                "startTime": "2025-03-23T10:00:00Z",
+                "endTime": "2025-03-23T11:00:00Z",
+              }),
+            ),
+          ),
+          // Tool call for add_outdoor_location
+          OpenAIResponseToolCall(
+            id: "tool-call-4",
+            type: "function_call",
+            function: OpenAIResponseFunction(
+              name: "add_outdoor_location",
+              arguments: jsonEncode({
+                "locationName": "Starbucks",
+                "duration": 1800, // 30 minutes
+              }),
+            ),
+          ),
+          OpenAIResponseToolCall(
+            id: "tool-call-4",
+            type: "function_call",
+            function: OpenAIResponseFunction(
+              name: "add_outdoor_event",
+              arguments: jsonEncode({
+                "locationName": "bababooey",
+                "startTime": "2025-03-23T10:00:00Z",
+                "endTime": "2025-03-23T11:00:00Z",
+              }),
+            ),
+          ),
+        ],
+      ),
+      finishReason: "tool_calls",
+    ),
+  ],
+  usage: const OpenAIChatCompletionUsageModel(
+    promptTokens: 50,
+    completionTokens: 100,
+    totalTokens: 150,
+  ),
+);
+
+@GenerateMocks([OpenAI])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   dotenv.load(fileName: '.env');
@@ -79,6 +182,159 @@ void main() {
   });
 
   group('SmartPlannerView Flow Tests', () {
+    late PlacesService placesService;
+    late MockClient mockClient;
+
+    final mockResponse = jsonEncode({
+      'places': [
+        {
+          'id': 'place_1',
+          'displayName': {'text': 'Starbucks'},
+          'name': 'Starbucks',
+          'formattedAddress':
+              '1453 Mackay St LB Building, Montreal, QC H3G 2H6',
+          'location': {
+            'latitude': 45.4215,
+            'longitude': -75.6972,
+          },
+          'rating': 4.5,
+          'types': ['restaurant', 'food'],
+          'currentOpeningHours': {'openNow': true},
+          'nationalPhoneNumber': '+1234567890',
+          'internationalPhoneNumber': '+1234567890',
+          'websiteUri': 'https://example.com',
+          'primaryType': 'restaurant',
+          'userRatingCount': 150,
+          'priceLevel': '2',
+          'accessibilityOptions': {
+            'wheelchairAccessibleParking': true,
+            'wheelchairAccessibleEntrance': true,
+            'wheelchairAccessibleRestroom': false,
+            'wheelchairAccessibleSeating': true,
+          },
+        },
+      ],
+      'routingSummaries': [
+        {
+          'distance': 1500,
+          'duration': 300,
+        },
+      ],
+    });
+
+    setUp(() {
+      mockClient = MockClient();
+      placesService = PlacesService(mockClient);
+    });
+
+    test('getNearbyPlaces throws exception', () async {
+      // Arrange
+      final PlacesRepository repo = PlacesRepository(placesService);
+
+      const location =
+          LatLng(45.4215, -75.6972); // Example coordinates (Ottawa)
+      const radius = 1500.0;
+      const type = PlaceType.coffeeShop;
+
+      when(mockClient.get(any))
+          .thenAnswer((_) async => http.Response(mockResponse, 400));
+      when(mockClient.post(
+        any,
+        headers: anyNamed('headers'),
+        body: anyNamed('body'),
+      )).thenAnswer((_) async => http.Response(mockResponse, 400));
+
+      // Act
+      try {
+        await repo.getNearbyPlaces(
+          location: location,
+          radius: radius,
+          type: type,
+        );
+      } catch (e) {
+        expect(e, isA<Exception>());
+      }
+    });
+
+    test('textSearchPlaces throws exception', () async {
+      // Arrange
+      const query = 'coffee shop';
+      const location =
+          LatLng(45.4215, -75.6972); // Example coordinates (Ottawa)
+      const radius = 1500.0;
+      const type = PlaceType.coffeeShop;
+      const openNow = true;
+      final PlacesRepository repo = PlacesRepository(placesService);
+
+      when(mockClient.get(any))
+          .thenAnswer((_) async => http.Response(mockResponse, 400));
+      when(mockClient.post(
+        any,
+        headers: anyNamed('headers'),
+        body: anyNamed('body'),
+      )).thenAnswer((_) async => http.Response(mockResponse, 400));
+
+      // Act
+      try {
+        await repo.textSearchPlaces(
+          query: query,
+          location: location,
+          radius: radius,
+          type: type,
+          openNow: openNow,
+        );
+      } catch (e) {
+        expect(e, isA<Exception>());
+      }
+    });
+
+    testWidgets('SmartPlannerView - Press on Generate Plan',
+        (WidgetTester tester) async {
+      // Build our app and trigger a frame.
+
+      when(mockClient.get(any))
+          .thenAnswer((_) async => http.Response(mockResponse, 200));
+      when(mockClient.post(
+        any,
+        headers: anyNamed('headers'),
+        body: anyNamed('body'),
+      )).thenAnswer((_) async => http.Response(mockResponse, 200));
+
+      testPosition = Position(
+          longitude: -73.5788992164221,
+          latitude: 45.4952628500172,
+          timestamp: DateTime.now(),
+          accuracy: 10.0,
+          altitude: 20.0,
+          heading: 120,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+          altitudeAccuracy: 0.0,
+          headingAccuracy: 0.0);
+
+      final SmartPlannerService mockService = SmartPlannerService(
+          response: mockChatResponse, placesService: placesService);
+
+      final routes = {
+        '/SmartPlannerView': (context) => SmartPlannerView(
+            mapViewModel: mockMapViewModel, smartPlannerService: mockService),
+      };
+
+      // Build the HomePage widget
+      await tester.pumpWidget(MaterialApp(
+        initialRoute: '/SmartPlannerView',
+        routes: routes,
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first,
+          'I have to attend a seminar at the J.W. McConnell Building from 9 am to 9:30 am, I have a lecture in H 9.27 from 10:00 am to 11:00 am, and go to a coffee shop for 30 minutes, and I also have to go to Hall Building for 20 minutes.');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text("Make Plan"));
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('Tap on the smart planner button from home page',
         (WidgetTester tester) async {
       // Build our app and trigger a frame.
@@ -106,11 +362,42 @@ void main() {
 
     testWidgets('Navigate to SmartPlannerView from HomePage and create a plan',
         (WidgetTester tester) async {
-      // Build our app and trigger a frame.
+      final samplePlan = TravellingSalesmanRequest(
+        [
+          (
+            "Place A",
+            const Location(45.5017, -73.5673, "Place A", "Description",
+                "Category", "Address", "Building Code"),
+            900
+          ),
+          (
+            "Place B",
+            const Location(45.5017, -73.5673, "Place A", "Description",
+                "Category", "Address", "Building Code"),
+            1200
+          ),
+        ],
+        [
+          (
+            "Meeting",
+            const Location(45.5017, -73.5673, "Place A", "Description",
+                "Category", "Address", "Building Code"),
+            DateTime(2025, 3, 24, 14, 0),
+            DateTime(2025, 3, 24, 15, 0)
+          )
+        ],
+        DateTime(2025, 3, 24, 9, 0),
+        const Location(45.5017, -73.5673, "Place A", "Description", "Category",
+            "Address", "Building Code"),
+      );
+
       final routes = {
-        '/': (context) =>
-            SmartPlannerView(mapViewModel: mockMapViewModel),
-        '/GeneratedPlanView': (context) => const GeneratedPlanView()
+        '/': (context) => SmartPlannerView(mapViewModel: mockMapViewModel),
+        '/GeneratedPlanView': (context) {
+          return GeneratedPlanView(
+            plan: samplePlan,
+          );
+        }
       };
 
       // Build the HomePage widget
@@ -149,16 +436,6 @@ void main() {
       // Check if source is updated
       expect(find.byType(TextField).at(1),
           findsOneWidget); // Second TextField is source
-      expect(find.textContaining("Building"),
-          findsOneWidget); // Assumes a building is chosen
-
-      // Now "Make Plan" should be enabled
-      expect(
-          tester.widget<ElevatedButton>(makePlanButton).onPressed, isNotNull);
-
-      // Tap on "Make Plan"
-      await tester.tap(makePlanButton);
-      await tester.pumpAndSettle();
     });
 
     testWidgets(


### PR DESCRIPTION
### 🛠 Proposed Changes:

Add function calling from openai using v5.1.0 of `dart_openai`.

### 📝 Details:

- Adds an Input Guide on the Smart Planner Page
- Add a `smart_planner_service.dart` file to add items to `event` or `toDoLocation` Lists by associating data from our catalog, consisting of locations from `places_repository.dart`, `building_repository.dart` and  `building_data_manager.dart`.
- Add a helper `buildingByName` function for `building_repository.dart`


<details><summary>An example of a natural language prompt being formatted into a TSP request is as follows (click dropdown to reveal):</summary>

1. The user enters their prompt, adhering to the basic formatting. In the screenshots below, the prompt used was: "_I have to attend a seminar at the J.W. McConnell Building from 9 am to 9:30 am, I have a lecture in H 9.27 from 10:00 am to 11:00 am, and go to a coffee shop for 30 minutes, and I also have to go to Hall Building for 20 minutes._
"

![image](https://github.com/user-attachments/assets/fe0ce69f-6dd4-4df8-8613-d94188516d1b)

2. The user is brought to the Generated Plan screen for the time being to show the currently unoptimized plan, comprised of events (those with a fixed start+end time,) and free locations (those with only a duration, e.g. getting coffee for 20 minutes).

![image](https://github.com/user-attachments/assets/ab66f899-588b-4956-bdbc-f661d4867e8b)

A uuid is created that is unique across both events and todos to conform to the TravellingSalesmanRequest schema from the domain model. There's also dev logs to confirm that items are indeed the right runtime type. For example, an event taking place in H 9.27 should be a ConcordiaRoom:
![image](https://github.com/user-attachments/assets/2b18057b-258a-4c18-87ed-154beca0a1c7)

</details>


### 🔗 Related Issue(s):

- Resolves #277
- Related `concordia_nav/lib/data/domain-model/travelling_salesman_request.dart` file from #312 