### PR TITLE
Add support for remembering preferred calendars

### DIFF
--- a/concordia_nav/ios/Podfile.lock
+++ b/concordia_nav/ios/Podfile.lock
@@ -4,6 +4,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_env_native (0.0.1):
     - Flutter
+  - geocoding_ios (1.0.5):
+    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
   - Google-Maps-iOS-Utils (5.0.0):
@@ -19,14 +21,22 @@ PODS:
     - GoogleMaps/Base
   - integration_test (0.0.1):
     - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - device_calendar (from `.symlinks/plugins/device_calendar/ios`)
   - Flutter (from `Flutter`)
   - flutter_env_native (from `.symlinks/plugins/flutter_env_native/ios`)
+  - geocoding_ios (from `.symlinks/plugins/geocoding_ios/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -40,22 +50,31 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_env_native:
     :path: ".symlinks/plugins/flutter_env_native/ios"
+  geocoding_ios:
+    :path: ".symlinks/plugins/geocoding_ios/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/ios"
   google_maps_flutter_ios:
     :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   device_calendar: b55b2c5406cfba45c95a59f9059156daee1f74ed
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_env_native: 1ffd562384b97c82279738dcce4edeeb01857dee
+  geocoding_ios: bcbdaa6bddd7d3129c9bcb8acddc5d8778689768
   geolocator_apple: 1560c3c875af2a412242c7a923e15d0d401966ff
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: d564ec28c1549dab5400f761b476823113375bf4
 

--- a/concordia_nav/lib/data/repositories/building_repository.dart
+++ b/concordia_nav/lib/data/repositories/building_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as dev;
 import 'package:flutter/foundation.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:flutter/services.dart';
@@ -267,7 +268,7 @@ class BuildingRepository {
       return {"polygons": polygons, "labels": labelPositions};
     } on Error catch (e) {
       if (kDebugMode) {
-        print('Error loading building polygons and labels: $e');
+        dev.log('Error loading building polygons and labels: $e');
       }
       return {"polygons": {}, "labels": {}};
     }

--- a/concordia_nav/lib/data/services/helpers/icon_loader.dart
+++ b/concordia_nav/lib/data/services/helpers/icon_loader.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as dev;
 import 'dart:ui' as ui;
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
@@ -30,7 +31,7 @@ class IconLoader {
     try {
       data = await loadFunction(iconPath);
     } on FlutterError catch (e) {
-      debugPrint("Error loading icon $iconPath: $e");
+      dev.log("Error loading icon $iconPath: $e");
       data = await rootBundle.load('assets/icons/default.png');
     }
 

--- a/concordia_nav/lib/data/services/helpers/polygon_loader.dart
+++ b/concordia_nav/lib/data/services/helpers/polygon_loader.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as dev;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -47,7 +48,7 @@ class PolygonLoader {
       return {"polygons": polygons, "labels": labelPositions};
     } on Error catch (e) {
       if (kDebugMode) {
-        print('Error loading polygons: $e');
+        dev.log('Error loading polygons: $e');
       }
       return {"polygons": {}, "labels": {}};
     }

--- a/concordia_nav/lib/ui/next_class/next_class_directions_view.dart
+++ b/concordia_nav/lib/ui/next_class/next_class_directions_view.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as dev;
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -223,7 +224,7 @@ class NextClassDirectionsPreviewState
           : "";
       setState(() => _staticMapUrl = newMapUrl);
     } on Error catch (e) {
-      debugPrint("Error fetching location: $e");
+      dev.log("Error fetching location: $e");
     } finally {
       setState(() => _isFetchingInitialLocation = false);
     }

--- a/concordia_nav/lib/utils/indoor_step_viewmodel.dart
+++ b/concordia_nav/lib/utils/indoor_step_viewmodel.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: unused_local_variable, avoid_catches_without_on_clauses
 
+import 'dart:developer' as dev;
+
 import 'package:flutter/material.dart';
 import '../../data/domain-model/floor_routable_point.dart';
 import '../../data/services/routecalculation_service.dart';
@@ -104,7 +106,7 @@ class VirtualStepGuideViewModel extends ChangeNotifier {
       height = size.height;
       notifyListeners();
     } catch (e) {
-      debugPrint('Error getting SVG dimensions: $e');
+      dev.log('Error getting SVG dimensions: $e');
     }
   }
 
@@ -129,7 +131,7 @@ class VirtualStepGuideViewModel extends ChangeNotifier {
         calculateTimeAndDistanceEstimates();
       }
     } catch (e) {
-      debugPrint('Error calculating route: $e');
+      dev.log('Error calculating route: $e');
     } finally {
       isLoading = false;
       notifyListeners();

--- a/concordia_nav/lib/utils/map_viewmodel.dart
+++ b/concordia_nav/lib/utils/map_viewmodel.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as dev;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -266,7 +267,7 @@ class MapViewModel extends ChangeNotifier {
       bool destNearLOY, bool destNearSGW) {
     if ((!originNearLOY && !originNearSGW) || (!destNearLOY && !destNearSGW)) {
       if (kDebugMode) {
-        print(
+        dev.log(
             "Shuttle route not available: One or both addresses are not within 1km of a campus shuttle stop.");
       }
       return false;
@@ -274,7 +275,7 @@ class MapViewModel extends ChangeNotifier {
     // If both addresses are near the same campus, there's no shuttle route.
     if ((originNearLOY && destNearLOY) || (originNearSGW && destNearSGW)) {
       if (kDebugMode) {
-        print(
+        dev.log(
             "Shuttle route not available: Both addresses are near the same campus shuttle stop.");
       }
       return false;
@@ -292,7 +293,7 @@ class MapViewModel extends ChangeNotifier {
         return ShuttleRouteDirection.campusLOYtoSGW;
       } else {
         if (kDebugMode) {
-          print(
+          dev.log(
               "Shuttle route not available: Addresses do not meet valid shuttle range criteria.");
         }
         return null;
@@ -343,7 +344,7 @@ class MapViewModel extends ChangeNotifier {
 
     if (originCoords == null || destinationCoords == null) {
       if (kDebugMode) {
-        print("Shuttle route not available: Cannot determine coordinates.");
+        dev.log("Shuttle route not available: Cannot determine coordinates.");
       }
       return ShuttleRouteDetails(
         originCoords: null,
@@ -718,13 +719,13 @@ class MapViewModel extends ChangeNotifier {
         shuttleMarkersNotifier.value = newMarkers;
       } else {
         if (kDebugMode) {
-          print(
+          dev.log(
               "Error fetching shuttle bus data: POST status ${postResponse.statusCode}");
         }
       }
     } on Error catch (e) {
       if (kDebugMode) {
-        print("Error fetching shuttle bus data: $e");
+        dev.log("Error fetching shuttle bus data: $e");
       }
     }
   }

--- a/concordia_nav/pubspec.lock
+++ b/concordia_nav/pubspec.lock
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   fetch_api:
     dependency: transitive
     description:
@@ -270,6 +270,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -616,10 +624,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -764,6 +772,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -844,6 +876,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3ec7210872c4ba945e3244982918e502fa2bfb5230dff6832459ca0e1879b7ad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.8"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1133,10 +1221,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -1173,10 +1261,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1185,6 +1273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -1202,5 +1298,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/concordia_nav/pubspec.lock
+++ b/concordia_nav/pubspec.lock
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   fetch_api:
     dependency: transitive
     description:
@@ -624,10 +624,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1221,10 +1221,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:
@@ -1261,10 +1261,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/concordia_nav/pubspec.yaml
+++ b/concordia_nav/pubspec.yaml
@@ -85,6 +85,7 @@ dependencies:
   logger: ^2.5.0
   google_places_flutter: ^2.1.0
   dart_openai: ^5.1.0
+  shared_preferences: ^2.5.2
 
 dev_dependencies:
   flutter_test:

--- a/concordia_nav/test/calendar/calendar_link_test.dart
+++ b/concordia_nav/test/calendar/calendar_link_test.dart
@@ -1,8 +1,16 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:concordia_nav/ui/setting/calendar/calendar_link_view.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
+
   group('calendar link page', () {
     testWidgets('all widgets are present', (WidgetTester tester) async {
       // Build CalendarLink view page

--- a/concordia_nav/test/calendar/calendar_link_view_test.dart
+++ b/concordia_nav/test/calendar/calendar_link_view_test.dart
@@ -1,8 +1,16 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:concordia_nav/ui/setting/calendar/calendar_view.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
+
   group('CalendarView Widget Tests', () {
     testWidgets('renders CalendarView with custom AppBar and correct body text',
         (WidgetTester tester) async {

--- a/concordia_nav/test/calendar/calendar_page_test.dart
+++ b/concordia_nav/test/calendar/calendar_page_test.dart
@@ -1,8 +1,15 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:concordia_nav/ui/setting/calendar/calendar_view.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
   group('calendarPage appBar', () {
     testWidgets('appBar should exist with the right title',
         (WidgetTester tester) async {

--- a/concordia_nav/test/calendar/calendar_repository_test.dart
+++ b/concordia_nav/test/calendar/calendar_repository_test.dart
@@ -1,16 +1,23 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'dart:collection';
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
-import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:device_calendar/device_calendar.dart';
 import 'package:concordia_nav/data/repositories/calendar.dart';
 import 'calendar_repository_test.mocks.dart';
 
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+
 @GenerateNiceMocks([MockSpec<DeviceCalendarPlugin>()])
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
   group('UserCalendar', () {
-    
     test('UserCalendar instances with the same calendarId are equal', () {
       // Arrange
       final calendar1 = UserCalendar('1', 'Calendar 1');

--- a/concordia_nav/test/calendar/calendar_selection_viewmodel_test.dart
+++ b/concordia_nav/test/calendar/calendar_selection_viewmodel_test.dart
@@ -1,20 +1,26 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:concordia_nav/data/repositories/calendar.dart';
 import 'package:concordia_nav/utils/calendar_selection_viewmodel.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 import '../indoor_map/indoor_routing_service_test.mocks.dart';
 
 @GenerateMocks([CalendarRepository])
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
   late MockCalendarRepository mockCalendarRepository;
 
   setUp(() {
     mockCalendarRepository = MockCalendarRepository();
   });
 
-  group('CalendarSelectionViewModel tests', (){
+  group('CalendarSelectionViewModel tests', () {
     test('loadCalendars updates the list of calendars', () async {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
@@ -25,10 +31,10 @@ void main() {
       final calendars = [calendar1, calendar2];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      
+
       final calendarSelectionViewModel = CalendarSelectionViewModel();
       calendarSelectionViewModel.calendarRepository = mockCalendarRepository;
-      
+
       // Act
       await calendarSelectionViewModel.loadCalendars();
 
@@ -41,10 +47,10 @@ void main() {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
           .thenAnswer((_) async => false);
-      
+
       final calendarSelectionViewModel = CalendarSelectionViewModel();
       calendarSelectionViewModel.calendarRepository = mockCalendarRepository;
-      
+
       expect(calendarSelectionViewModel.loadCalendars(), throwsException);
     });
 
@@ -87,7 +93,8 @@ void main() {
       expect(calendarSelectionViewModel.isCalendarSelected(calendar), false);
     });
 
-    test('getSelectedCalendars returns the list of selected calendars', () async {
+    test('getSelectedCalendars returns the list of selected calendars',
+        () async {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
           .thenAnswer((_) async => true);
@@ -98,7 +105,7 @@ void main() {
       final calendars = [calendar1, calendar2, calendar3];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      
+
       final calendarSelectionViewModel = CalendarSelectionViewModel();
       calendarSelectionViewModel.calendarRepository = mockCalendarRepository;
       await calendarSelectionViewModel.loadCalendars();
@@ -106,14 +113,16 @@ void main() {
       calendarSelectionViewModel.selectCalendar(calendar3);
 
       // Act
-      final selectedCalendars = calendarSelectionViewModel.getSelectedCalendars();
+      final selectedCalendars =
+          calendarSelectionViewModel.getSelectedCalendars();
 
       // Assert
       expect(selectedCalendars[0], calendar1);
       expect(selectedCalendars[1], calendar3);
     });
 
-    test('selectCalendarsByDisplayName selects calendar by its display name', () async {
+    test('selectCalendarsByDisplayName selects calendar by its display name',
+        () async {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
           .thenAnswer((_) async => true);
@@ -124,7 +133,7 @@ void main() {
       final calendars = [calendar1, calendar2, calendar3];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      
+
       final calendarSelectionViewModel = CalendarSelectionViewModel();
       calendarSelectionViewModel.calendarRepository = mockCalendarRepository;
       await calendarSelectionViewModel.loadCalendars();
@@ -136,7 +145,9 @@ void main() {
       expect(calendarSelectionViewModel.isCalendarSelected(calendar1), true);
     });
 
-    test('getSelectedCalendarsByDisplayName returns a list of calendars matching display name', () async {
+    test(
+        'getSelectedCalendarsByDisplayName returns a list of calendars matching display name',
+        () async {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
           .thenAnswer((_) async => true);
@@ -147,7 +158,7 @@ void main() {
       final calendars = [calendar1, calendar2, calendar3];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      
+
       final calendarSelectionViewModel = CalendarSelectionViewModel();
       calendarSelectionViewModel.calendarRepository = mockCalendarRepository;
       await calendarSelectionViewModel.loadCalendars();
@@ -155,7 +166,8 @@ void main() {
       calendarSelectionViewModel.selectCalendar(calendar3);
 
       // Act
-      final selectedCalendars = calendarSelectionViewModel.getSelectedCalendarsByDisplayName('Calendar 1');
+      final selectedCalendars = calendarSelectionViewModel
+          .getSelectedCalendarsByDisplayName('Calendar 1');
 
       // Assert
       expect(selectedCalendars[0], calendar1);

--- a/concordia_nav/test/calendar/calendar_selection_viewmodel_test.mocks.dart
+++ b/concordia_nav/test/calendar/calendar_selection_viewmodel_test.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
-import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i5;
-import 'package:concordia_nav/data/repositories/calendar.dart' as _i3;
-import 'package:concordia_nav/utils/building_viewmodel.dart' as _i6;
+import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i6;
+import 'package:concordia_nav/data/repositories/calendar.dart' as _i4;
+import 'package:concordia_nav/utils/building_viewmodel.dart' as _i7;
 import 'package:device_calendar/device_calendar.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:shared_preferences/shared_preferences.dart' as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -31,11 +32,17 @@ class _FakeDeviceCalendarPlugin_0 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
+class _FakeSharedPreferencesAsync_1 extends _i1.SmartFake
+    implements _i3.SharedPreferencesAsync {
+  _FakeSharedPreferencesAsync_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [CalendarRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCalendarRepository extends _i1.Mock
-    implements _i3.CalendarRepository {
+    implements _i4.CalendarRepository {
   MockCalendarRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -58,26 +65,63 @@ class MockCalendarRepository extends _i1.Mock
   );
 
   @override
-  _i4.Future<bool> checkPermissions() =>
+  _i3.SharedPreferencesAsync get prefs =>
       (super.noSuchMethod(
-            Invocation.method(#checkPermissions, []),
-            returnValue: _i4.Future<bool>.value(false),
-          )
-          as _i4.Future<bool>);
-
-  @override
-  _i4.Future<List<_i3.UserCalendar>> getUserCalendars() =>
-      (super.noSuchMethod(
-            Invocation.method(#getUserCalendars, []),
-            returnValue: _i4.Future<List<_i3.UserCalendar>>.value(
-              <_i3.UserCalendar>[],
+            Invocation.getter(#prefs),
+            returnValue: _FakeSharedPreferencesAsync_1(
+              this,
+              Invocation.getter(#prefs),
             ),
           )
-          as _i4.Future<List<_i3.UserCalendar>>);
+          as _i3.SharedPreferencesAsync);
 
   @override
-  _i4.Future<List<_i3.UserCalendarEvent>> getEvents(
-    List<_i3.UserCalendar>? selectedCalendars,
+  set prefs(_i3.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+    Invocation.setter(#prefs, _prefs),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i5.Future<bool> checkPermissions() =>
+      (super.noSuchMethod(
+            Invocation.method(#checkPermissions, []),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i4.UserCalendar>> getUserCalendars({
+    dynamic preferredCalendarsOnly = false,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#getUserCalendars, [], {
+              #preferredCalendarsOnly: preferredCalendarsOnly,
+            }),
+            returnValue: _i5.Future<List<_i4.UserCalendar>>.value(
+              <_i4.UserCalendar>[],
+            ),
+          )
+          as _i5.Future<List<_i4.UserCalendar>>);
+
+  @override
+  _i5.Future<bool> isCalendarPreferred(_i4.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#isCalendarPreferred, [cal]),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> setUserCalendarPreferredState(_i4.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserCalendarPreferredState, [cal]),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i4.UserCalendarEvent>> getEvents(
+    List<_i4.UserCalendar>? selectedCalendars,
     Duration? timeSpan,
     DateTime? utcStart,
   ) =>
@@ -87,15 +131,15 @@ class MockCalendarRepository extends _i1.Mock
               timeSpan,
               utcStart,
             ]),
-            returnValue: _i4.Future<List<_i3.UserCalendarEvent>>.value(
-              <_i3.UserCalendarEvent>[],
+            returnValue: _i5.Future<List<_i4.UserCalendarEvent>>.value(
+              <_i4.UserCalendarEvent>[],
             ),
           )
-          as _i4.Future<List<_i3.UserCalendarEvent>>);
+          as _i5.Future<List<_i4.UserCalendarEvent>>);
 
   @override
-  _i4.Future<List<_i3.UserCalendarEvent>> getEventsOnLocalDate(
-    List<_i3.UserCalendar>? selectedCalendars,
+  _i5.Future<List<_i4.UserCalendarEvent>> getEventsOnLocalDate(
+    List<_i4.UserCalendar>? selectedCalendars,
     int? offset,
   ) =>
       (super.noSuchMethod(
@@ -103,33 +147,33 @@ class MockCalendarRepository extends _i1.Mock
               selectedCalendars,
               offset,
             ]),
-            returnValue: _i4.Future<List<_i3.UserCalendarEvent>>.value(
-              <_i3.UserCalendarEvent>[],
+            returnValue: _i5.Future<List<_i4.UserCalendarEvent>>.value(
+              <_i4.UserCalendarEvent>[],
             ),
           )
-          as _i4.Future<List<_i3.UserCalendarEvent>>);
+          as _i5.Future<List<_i4.UserCalendarEvent>>);
 
   @override
-  _i4.Future<_i3.UserCalendarEvent?> getNextClassEvent(
-    List<_i3.UserCalendar>? selectedCalendars,
+  _i5.Future<_i4.UserCalendarEvent?> getNextClassEvent(
+    List<_i4.UserCalendar>? selectedCalendars,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassEvent, [selectedCalendars]),
-            returnValue: _i4.Future<_i3.UserCalendarEvent?>.value(),
+            returnValue: _i5.Future<_i4.UserCalendarEvent?>.value(),
           )
-          as _i4.Future<_i3.UserCalendarEvent?>);
+          as _i5.Future<_i4.UserCalendarEvent?>);
 
   @override
-  _i4.Future<_i5.ConcordiaRoom?> getNextClassRoom(
-    List<_i3.UserCalendar>? selectedCalendars,
-    _i6.BuildingViewModel? buildingViewModel,
+  _i5.Future<_i6.ConcordiaRoom?> getNextClassRoom(
+    List<_i4.UserCalendar>? selectedCalendars,
+    _i7.BuildingViewModel? buildingViewModel,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassRoom, [
               selectedCalendars,
               buildingViewModel,
             ]),
-            returnValue: _i4.Future<_i5.ConcordiaRoom?>.value(),
+            returnValue: _i5.Future<_i6.ConcordiaRoom?>.value(),
           )
-          as _i4.Future<_i5.ConcordiaRoom?>);
+          as _i5.Future<_i6.ConcordiaRoom?>);
 }

--- a/concordia_nav/test/calendar/calendar_view_test.dart
+++ b/concordia_nav/test/calendar/calendar_view_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'dart:collection';
 
 import 'package:calendar_view/calendar_view.dart';
@@ -14,6 +16,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+
 import '../settings/calendar_view_test.mocks.dart';
 import 'calendar_repository_test.mocks.dart';
 import 'calendar_view_test.mocks.dart';
@@ -21,6 +26,10 @@ import 'calendar_view_test.mocks.dart';
 @GenerateMocks(
     [CalendarRepository, CalendarSelectionViewModel, CalendarViewModel])
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
+
   late CalendarRepository calendarRepository;
   late MockDeviceCalendarPlugin mockPlugin;
   late MockCalendarViewModel mockCalendarViewModel;

--- a/concordia_nav/test/calendar/calendar_view_test.mocks.dart
+++ b/concordia_nav/test/calendar/calendar_view_test.mocks.dart
@@ -3,18 +3,19 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
-import 'dart:ui' as _i11;
+import 'dart:async' as _i5;
+import 'dart:ui' as _i12;
 
-import 'package:calendar_view/calendar_view.dart' as _i9;
-import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i5;
-import 'package:concordia_nav/data/repositories/calendar.dart' as _i3;
-import 'package:concordia_nav/utils/building_viewmodel.dart' as _i6;
-import 'package:concordia_nav/utils/calendar_selection_viewmodel.dart' as _i7;
-import 'package:concordia_nav/utils/calendar_viewmodel.dart' as _i8;
+import 'package:calendar_view/calendar_view.dart' as _i10;
+import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i6;
+import 'package:concordia_nav/data/repositories/calendar.dart' as _i4;
+import 'package:concordia_nav/utils/building_viewmodel.dart' as _i7;
+import 'package:concordia_nav/utils/calendar_selection_viewmodel.dart' as _i8;
+import 'package:concordia_nav/utils/calendar_viewmodel.dart' as _i9;
 import 'package:device_calendar/device_calendar.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:mockito/src/dummies.dart' as _i11;
+import 'package:shared_preferences/shared_preferences.dart' as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -36,11 +37,17 @@ class _FakeDeviceCalendarPlugin_0 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
+class _FakeSharedPreferencesAsync_1 extends _i1.SmartFake
+    implements _i3.SharedPreferencesAsync {
+  _FakeSharedPreferencesAsync_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [CalendarRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCalendarRepository extends _i1.Mock
-    implements _i3.CalendarRepository {
+    implements _i4.CalendarRepository {
   MockCalendarRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -63,26 +70,63 @@ class MockCalendarRepository extends _i1.Mock
   );
 
   @override
-  _i4.Future<bool> checkPermissions() =>
+  _i3.SharedPreferencesAsync get prefs =>
       (super.noSuchMethod(
-            Invocation.method(#checkPermissions, []),
-            returnValue: _i4.Future<bool>.value(false),
-          )
-          as _i4.Future<bool>);
-
-  @override
-  _i4.Future<List<_i3.UserCalendar>> getUserCalendars() =>
-      (super.noSuchMethod(
-            Invocation.method(#getUserCalendars, []),
-            returnValue: _i4.Future<List<_i3.UserCalendar>>.value(
-              <_i3.UserCalendar>[],
+            Invocation.getter(#prefs),
+            returnValue: _FakeSharedPreferencesAsync_1(
+              this,
+              Invocation.getter(#prefs),
             ),
           )
-          as _i4.Future<List<_i3.UserCalendar>>);
+          as _i3.SharedPreferencesAsync);
 
   @override
-  _i4.Future<List<_i3.UserCalendarEvent>> getEvents(
-    List<_i3.UserCalendar>? selectedCalendars,
+  set prefs(_i3.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+    Invocation.setter(#prefs, _prefs),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i5.Future<bool> checkPermissions() =>
+      (super.noSuchMethod(
+            Invocation.method(#checkPermissions, []),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i4.UserCalendar>> getUserCalendars({
+    dynamic preferredCalendarsOnly = false,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#getUserCalendars, [], {
+              #preferredCalendarsOnly: preferredCalendarsOnly,
+            }),
+            returnValue: _i5.Future<List<_i4.UserCalendar>>.value(
+              <_i4.UserCalendar>[],
+            ),
+          )
+          as _i5.Future<List<_i4.UserCalendar>>);
+
+  @override
+  _i5.Future<bool> isCalendarPreferred(_i4.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#isCalendarPreferred, [cal]),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> setUserCalendarPreferredState(_i4.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserCalendarPreferredState, [cal]),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i4.UserCalendarEvent>> getEvents(
+    List<_i4.UserCalendar>? selectedCalendars,
     Duration? timeSpan,
     DateTime? utcStart,
   ) =>
@@ -92,15 +136,15 @@ class MockCalendarRepository extends _i1.Mock
               timeSpan,
               utcStart,
             ]),
-            returnValue: _i4.Future<List<_i3.UserCalendarEvent>>.value(
-              <_i3.UserCalendarEvent>[],
+            returnValue: _i5.Future<List<_i4.UserCalendarEvent>>.value(
+              <_i4.UserCalendarEvent>[],
             ),
           )
-          as _i4.Future<List<_i3.UserCalendarEvent>>);
+          as _i5.Future<List<_i4.UserCalendarEvent>>);
 
   @override
-  _i4.Future<List<_i3.UserCalendarEvent>> getEventsOnLocalDate(
-    List<_i3.UserCalendar>? selectedCalendars,
+  _i5.Future<List<_i4.UserCalendarEvent>> getEventsOnLocalDate(
+    List<_i4.UserCalendar>? selectedCalendars,
     int? offset,
   ) =>
       (super.noSuchMethod(
@@ -108,71 +152,71 @@ class MockCalendarRepository extends _i1.Mock
               selectedCalendars,
               offset,
             ]),
-            returnValue: _i4.Future<List<_i3.UserCalendarEvent>>.value(
-              <_i3.UserCalendarEvent>[],
+            returnValue: _i5.Future<List<_i4.UserCalendarEvent>>.value(
+              <_i4.UserCalendarEvent>[],
             ),
           )
-          as _i4.Future<List<_i3.UserCalendarEvent>>);
+          as _i5.Future<List<_i4.UserCalendarEvent>>);
 
   @override
-  _i4.Future<_i3.UserCalendarEvent?> getNextClassEvent(
-    List<_i3.UserCalendar>? selectedCalendars,
+  _i5.Future<_i4.UserCalendarEvent?> getNextClassEvent(
+    List<_i4.UserCalendar>? selectedCalendars,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassEvent, [selectedCalendars]),
-            returnValue: _i4.Future<_i3.UserCalendarEvent?>.value(),
+            returnValue: _i5.Future<_i4.UserCalendarEvent?>.value(),
           )
-          as _i4.Future<_i3.UserCalendarEvent?>);
+          as _i5.Future<_i4.UserCalendarEvent?>);
 
   @override
-  _i4.Future<_i5.ConcordiaRoom?> getNextClassRoom(
-    List<_i3.UserCalendar>? selectedCalendars,
-    _i6.BuildingViewModel? buildingViewModel,
+  _i5.Future<_i6.ConcordiaRoom?> getNextClassRoom(
+    List<_i4.UserCalendar>? selectedCalendars,
+    _i7.BuildingViewModel? buildingViewModel,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassRoom, [
               selectedCalendars,
               buildingViewModel,
             ]),
-            returnValue: _i4.Future<_i5.ConcordiaRoom?>.value(),
+            returnValue: _i5.Future<_i6.ConcordiaRoom?>.value(),
           )
-          as _i4.Future<_i5.ConcordiaRoom?>);
+          as _i5.Future<_i6.ConcordiaRoom?>);
 }
 
 /// A class which mocks [CalendarSelectionViewModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCalendarSelectionViewModel extends _i1.Mock
-    implements _i7.CalendarSelectionViewModel {
+    implements _i8.CalendarSelectionViewModel {
   MockCalendarSelectionViewModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set calendarRepository(_i3.CalendarRepository? repo) => super.noSuchMethod(
+  set calendarRepository(_i4.CalendarRepository? repo) => super.noSuchMethod(
     Invocation.setter(#calendarRepository, repo),
     returnValueForMissingStub: null,
   );
 
   @override
-  List<_i3.UserCalendar> get calendars =>
+  List<_i4.UserCalendar> get calendars =>
       (super.noSuchMethod(
             Invocation.getter(#calendars),
-            returnValue: <_i3.UserCalendar>[],
+            returnValue: <_i4.UserCalendar>[],
           )
-          as List<_i3.UserCalendar>);
+          as List<_i4.UserCalendar>);
 
   @override
-  _i4.Future<void> loadCalendars() =>
+  _i5.Future<void> loadCalendars() =>
       (super.noSuchMethod(
             Invocation.method(#loadCalendars, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  bool isCalendarSelected(_i3.UserCalendar? calendar) =>
+  bool isCalendarSelected(_i4.UserCalendar? calendar) =>
       (super.noSuchMethod(
             Invocation.method(#isCalendarSelected, [calendar]),
             returnValue: false,
@@ -180,31 +224,31 @@ class MockCalendarSelectionViewModel extends _i1.Mock
           as bool);
 
   @override
-  void selectCalendar(_i3.UserCalendar? calendar) => super.noSuchMethod(
+  void selectCalendar(_i4.UserCalendar? calendar) => super.noSuchMethod(
     Invocation.method(#selectCalendar, [calendar]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void unselectCalendar(_i3.UserCalendar? calendar) => super.noSuchMethod(
+  void unselectCalendar(_i4.UserCalendar? calendar) => super.noSuchMethod(
     Invocation.method(#unselectCalendar, [calendar]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void toggleCalendarSelection(_i3.UserCalendar? calendar) =>
+  void toggleCalendarSelection(_i4.UserCalendar? calendar) =>
       super.noSuchMethod(
         Invocation.method(#toggleCalendarSelection, [calendar]),
         returnValueForMissingStub: null,
       );
 
   @override
-  List<_i3.UserCalendar> getSelectedCalendars() =>
+  List<_i4.UserCalendar> getSelectedCalendars() =>
       (super.noSuchMethod(
             Invocation.method(#getSelectedCalendars, []),
-            returnValue: <_i3.UserCalendar>[],
+            returnValue: <_i4.UserCalendar>[],
           )
-          as List<_i3.UserCalendar>);
+          as List<_i4.UserCalendar>);
 
   @override
   void selectCalendarsByDisplayName(String? displayName) => super.noSuchMethod(
@@ -213,49 +257,49 @@ class MockCalendarSelectionViewModel extends _i1.Mock
   );
 
   @override
-  List<_i3.UserCalendar> getSelectedCalendarsByDisplayName(
+  List<_i4.UserCalendar> getSelectedCalendarsByDisplayName(
     String? displayName,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getSelectedCalendarsByDisplayName, [
               displayName,
             ]),
-            returnValue: <_i3.UserCalendar>[],
+            returnValue: <_i4.UserCalendar>[],
           )
-          as List<_i3.UserCalendar>);
+          as List<_i4.UserCalendar>);
 }
 
 /// A class which mocks [CalendarViewModel].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCalendarViewModel extends _i1.Mock implements _i8.CalendarViewModel {
+class MockCalendarViewModel extends _i1.Mock implements _i9.CalendarViewModel {
   MockCalendarViewModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  List<_i3.UserCalendar> get allCalendars =>
+  List<_i4.UserCalendar> get allCalendars =>
       (super.noSuchMethod(
             Invocation.getter(#allCalendars),
-            returnValue: <_i3.UserCalendar>[],
+            returnValue: <_i4.UserCalendar>[],
           )
-          as List<_i3.UserCalendar>);
+          as List<_i4.UserCalendar>);
 
   @override
-  List<_i3.UserCalendar> get selectedCalendars =>
+  List<_i4.UserCalendar> get selectedCalendars =>
       (super.noSuchMethod(
             Invocation.getter(#selectedCalendars),
-            returnValue: <_i3.UserCalendar>[],
+            returnValue: <_i4.UserCalendar>[],
           )
-          as List<_i3.UserCalendar>);
+          as List<_i4.UserCalendar>);
 
   @override
-  List<_i3.UserCalendarEvent> get events =>
+  List<_i4.UserCalendarEvent> get events =>
       (super.noSuchMethod(
             Invocation.getter(#events),
-            returnValue: <_i3.UserCalendarEvent>[],
+            returnValue: <_i4.UserCalendarEvent>[],
           )
-          as List<_i3.UserCalendarEvent>);
+          as List<_i4.UserCalendarEvent>);
 
   @override
   bool get isLoading =>
@@ -263,13 +307,13 @@ class MockCalendarViewModel extends _i1.Mock implements _i8.CalendarViewModel {
           as bool);
 
   @override
-  set calendarRepository(_i3.CalendarRepository? repo) => super.noSuchMethod(
+  set calendarRepository(_i4.CalendarRepository? repo) => super.noSuchMethod(
     Invocation.setter(#calendarRepository, repo),
     returnValueForMissingStub: null,
   );
 
   @override
-  set eventsList(List<_i3.UserCalendarEvent>? events) => super.noSuchMethod(
+  set eventsList(List<_i4.UserCalendarEvent>? events) => super.noSuchMethod(
     Invocation.setter(#eventsList, events),
     returnValueForMissingStub: null,
   );
@@ -280,29 +324,29 @@ class MockCalendarViewModel extends _i1.Mock implements _i8.CalendarViewModel {
           as bool);
 
   @override
-  _i4.Future<void> initialize({_i3.UserCalendar? selectedCalendar}) =>
+  _i5.Future<void> initialize({_i4.UserCalendar? selectedCalendar}) =>
       (super.noSuchMethod(
             Invocation.method(#initialize, [], {
               #selectedCalendar: selectedCalendar,
             }),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i5.Future<void>);
 
   @override
-  List<_i9.CalendarEventData<Object?>> getCalendarEventData() =>
+  List<_i10.CalendarEventData<Object?>> getCalendarEventData() =>
       (super.noSuchMethod(
             Invocation.method(#getCalendarEventData, []),
-            returnValue: <_i9.CalendarEventData<Object?>>[],
+            returnValue: <_i10.CalendarEventData<Object?>>[],
           )
-          as List<_i9.CalendarEventData<Object?>>);
+          as List<_i10.CalendarEventData<Object?>>);
 
   @override
-  String formatEventTime(_i3.UserCalendarEvent? event) =>
+  String formatEventTime(_i4.UserCalendarEvent? event) =>
       (super.noSuchMethod(
             Invocation.method(#formatEventTime, [event]),
-            returnValue: _i10.dummyValue<String>(
+            returnValue: _i11.dummyValue<String>(
               this,
               Invocation.method(#formatEventTime, [event]),
             ),
@@ -313,7 +357,7 @@ class MockCalendarViewModel extends _i1.Mock implements _i8.CalendarViewModel {
   String getBuildingAbbreviation(String? location) =>
       (super.noSuchMethod(
             Invocation.method(#getBuildingAbbreviation, [location]),
-            returnValue: _i10.dummyValue<String>(
+            returnValue: _i11.dummyValue<String>(
               this,
               Invocation.method(#getBuildingAbbreviation, [location]),
             ),
@@ -321,13 +365,13 @@ class MockCalendarViewModel extends _i1.Mock implements _i8.CalendarViewModel {
           as String);
 
   @override
-  void addListener(_i11.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i12.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void removeListener(_i11.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i12.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#removeListener, [listener]),
     returnValueForMissingStub: null,
   );

--- a/concordia_nav/test/calendar/calendar_viewmodel_test.dart
+++ b/concordia_nav/test/calendar/calendar_viewmodel_test.dart
@@ -1,19 +1,28 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:concordia_nav/data/repositories/calendar.dart';
 import 'package:concordia_nav/utils/calendar_viewmodel.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+
 import '../indoor_map/indoor_routing_service_test.mocks.dart';
 
 @GenerateMocks([CalendarRepository])
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
+
   late MockCalendarRepository mockCalendarRepository;
 
   setUp(() {
     mockCalendarRepository = MockCalendarRepository();
   });
-  
+
   group('CalendarViewModel tests', () {
     test('initialize with no selectedCalendar param defaults to all', () async {
       // Arrange: checkPermissions accepted mock
@@ -25,24 +34,26 @@ void main() {
       final calendars = [calendar1, calendar2];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      final startDate = DateTime.now().copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
+      final startDate = DateTime.now()
+          .copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
       when(mockCalendarRepository.getEvents(
-          calendars, const Duration(days: 7), startDate))
-        .thenAnswer((_) async => []);
+              calendars, const Duration(days: 7), startDate))
+          .thenAnswer((_) async => []);
 
       // Act
       final calendarViewModel = CalendarViewModel();
       calendarViewModel.calendarRepository = mockCalendarRepository;
 
       await calendarViewModel.initialize();
-      
+
       // Assert
       expect(calendarViewModel.allCalendars, calendars);
       expect(calendarViewModel.selectedCalendars, calendars);
       expect(calendarViewModel.events, []);
     });
 
-    test('initialize with selectedCalendar param includes only selected', () async {
+    test('initialize with selectedCalendar param includes only selected',
+        () async {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
           .thenAnswer((_) async => true);
@@ -52,17 +63,18 @@ void main() {
       final calendars = [calendar1, calendar2];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      final startDate = DateTime.now().copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
+      final startDate = DateTime.now()
+          .copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
       when(mockCalendarRepository.getEvents(
-          calendars, const Duration(days: 7), startDate))
-        .thenAnswer((_) async => []);
+              calendars, const Duration(days: 7), startDate))
+          .thenAnswer((_) async => []);
 
       // Act
       final calendarViewModel = CalendarViewModel();
       calendarViewModel.calendarRepository = mockCalendarRepository;
 
       await calendarViewModel.initialize(selectedCalendar: calendar1);
-      
+
       // Assert
       expect(calendarViewModel.allCalendars, calendars);
       expect(calendarViewModel.selectedCalendars, [calendar1]);
@@ -82,7 +94,9 @@ void main() {
       expect(calendarViewModel.errorMessage, 'Calendar permission denied');
     });
 
-    test('getCalendarEventData converts UserCalendarEvents to CalendarEventdata', () async {
+    test(
+        'getCalendarEventData converts UserCalendarEvents to CalendarEventdata',
+        () async {
       // Arrange: checkPermissions accepted mock
       when(mockCalendarRepository.checkPermissions())
           .thenAnswer((_) async => true);
@@ -92,19 +106,24 @@ void main() {
       final calendars = [calendar1, calendar2];
       when(mockCalendarRepository.getUserCalendars())
           .thenAnswer((_) async => calendars);
-      final startDate = DateTime.now().copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
+      final startDate = DateTime.now()
+          .copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
       when(mockCalendarRepository.getEvents(
-          calendars, const Duration(days: 7), startDate))
-        .thenAnswer((_) async => []);
+              calendars, const Duration(days: 7), startDate))
+          .thenAnswer((_) async => []);
 
-      final startTime = DateTime.now().copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
-      final endTime = DateTime.now().copyWith(hour: 2, minute: 30, second: 0, millisecond: 0);
-      final startTime2 = DateTime.now().copyWith(hour: 3, minute: 0, second: 0, millisecond: 0);
-      final endTime2 = DateTime.now().copyWith(hour: 4, minute: 30, second: 0, millisecond: 0);
+      final startTime = DateTime.now()
+          .copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
+      final endTime = DateTime.now()
+          .copyWith(hour: 2, minute: 30, second: 0, millisecond: 0);
+      final startTime2 = DateTime.now()
+          .copyWith(hour: 3, minute: 0, second: 0, millisecond: 0);
+      final endTime2 = DateTime.now()
+          .copyWith(hour: 4, minute: 30, second: 0, millisecond: 0);
       final calendarEvent = UserCalendarEvent(
-        calendar1, '1', 'waaa', startTime, endTime, 'WAAA', 'H 937');
+          calendar1, '1', 'waaa', startTime, endTime, 'WAAA', 'H 937');
       final calendarEvent2 = UserCalendarEvent(
-        calendar1, '1', 'nooo', startTime2, endTime2, 'NOOO', 'H 837');
+          calendar1, '1', 'nooo', startTime2, endTime2, 'NOOO', 'H 837');
       final calendarEvents = [calendarEvent, calendarEvent2];
 
       final calendarViewModel = CalendarViewModel();
@@ -121,29 +140,36 @@ void main() {
 
     test('formatEventTime formats event time', () {
       final calendar = UserCalendar('1', 'Calendar 1');
-      final startTime = DateTime.now().copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
-      final endTime = DateTime.now().copyWith(hour: 2, minute: 30, second: 0, millisecond: 0);
+      final startTime = DateTime.now()
+          .copyWith(hour: 0, minute: 0, second: 0, millisecond: 0);
+      final endTime = DateTime.now()
+          .copyWith(hour: 2, minute: 30, second: 0, millisecond: 0);
       final calendarEvent = UserCalendarEvent(
-        calendar, '1', 'waaa', startTime, endTime, 'WAAA', 'H 937');
+          calendar, '1', 'waaa', startTime, endTime, 'WAAA', 'H 937');
 
       // Act
       final formattedEvent = CalendarViewModel().formatEventTime(calendarEvent);
 
       // Assert
-      final startFormat = '${startTime.hour}:${startTime.minute.toString().padLeft(2, '0')}';
-      final endFormat = '${endTime.hour}:${endTime.minute.toString().padLeft(2, '0')}';
+      final startFormat =
+          '${startTime.hour}:${startTime.minute.toString().padLeft(2, '0')}';
+      final endFormat =
+          '${endTime.hour}:${endTime.minute.toString().padLeft(2, '0')}';
 
       expect(formattedEvent, '$startFormat - $endFormat');
     });
 
-    test('getBuildingAbbreviation returns building abbreviation from location', () async {
-      final buildingAbbreviation = CalendarViewModel().getBuildingAbbreviation('H 937');
+    test('getBuildingAbbreviation returns building abbreviation from location',
+        () async {
+      final buildingAbbreviation =
+          CalendarViewModel().getBuildingAbbreviation('H 937');
 
       expect(buildingAbbreviation, 'H');
     });
 
     test('getBuildingAbbreviation returns empty if invalid location', () async {
-      final buildingAbbreviation = CalendarViewModel().getBuildingAbbreviation('937');
+      final buildingAbbreviation =
+          CalendarViewModel().getBuildingAbbreviation('937');
 
       expect(buildingAbbreviation, '');
     });

--- a/concordia_nav/test/calendar/calendar_viewmodel_test.mocks.dart
+++ b/concordia_nav/test/calendar/calendar_viewmodel_test.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
-import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i5;
-import 'package:concordia_nav/data/repositories/calendar.dart' as _i3;
-import 'package:concordia_nav/utils/building_viewmodel.dart' as _i6;
+import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i6;
+import 'package:concordia_nav/data/repositories/calendar.dart' as _i4;
+import 'package:concordia_nav/utils/building_viewmodel.dart' as _i7;
 import 'package:device_calendar/device_calendar.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:shared_preferences/shared_preferences.dart' as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -31,11 +32,17 @@ class _FakeDeviceCalendarPlugin_0 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
+class _FakeSharedPreferencesAsync_1 extends _i1.SmartFake
+    implements _i3.SharedPreferencesAsync {
+  _FakeSharedPreferencesAsync_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [CalendarRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCalendarRepository extends _i1.Mock
-    implements _i3.CalendarRepository {
+    implements _i4.CalendarRepository {
   MockCalendarRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -58,26 +65,63 @@ class MockCalendarRepository extends _i1.Mock
   );
 
   @override
-  _i4.Future<bool> checkPermissions() =>
+  _i3.SharedPreferencesAsync get prefs =>
       (super.noSuchMethod(
-            Invocation.method(#checkPermissions, []),
-            returnValue: _i4.Future<bool>.value(false),
-          )
-          as _i4.Future<bool>);
-
-  @override
-  _i4.Future<List<_i3.UserCalendar>> getUserCalendars() =>
-      (super.noSuchMethod(
-            Invocation.method(#getUserCalendars, []),
-            returnValue: _i4.Future<List<_i3.UserCalendar>>.value(
-              <_i3.UserCalendar>[],
+            Invocation.getter(#prefs),
+            returnValue: _FakeSharedPreferencesAsync_1(
+              this,
+              Invocation.getter(#prefs),
             ),
           )
-          as _i4.Future<List<_i3.UserCalendar>>);
+          as _i3.SharedPreferencesAsync);
 
   @override
-  _i4.Future<List<_i3.UserCalendarEvent>> getEvents(
-    List<_i3.UserCalendar>? selectedCalendars,
+  set prefs(_i3.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+    Invocation.setter(#prefs, _prefs),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i5.Future<bool> checkPermissions() =>
+      (super.noSuchMethod(
+            Invocation.method(#checkPermissions, []),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i4.UserCalendar>> getUserCalendars({
+    dynamic preferredCalendarsOnly = false,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#getUserCalendars, [], {
+              #preferredCalendarsOnly: preferredCalendarsOnly,
+            }),
+            returnValue: _i5.Future<List<_i4.UserCalendar>>.value(
+              <_i4.UserCalendar>[],
+            ),
+          )
+          as _i5.Future<List<_i4.UserCalendar>>);
+
+  @override
+  _i5.Future<bool> isCalendarPreferred(_i4.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#isCalendarPreferred, [cal]),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> setUserCalendarPreferredState(_i4.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserCalendarPreferredState, [cal]),
+            returnValue: _i5.Future<bool>.value(false),
+          )
+          as _i5.Future<bool>);
+
+  @override
+  _i5.Future<List<_i4.UserCalendarEvent>> getEvents(
+    List<_i4.UserCalendar>? selectedCalendars,
     Duration? timeSpan,
     DateTime? utcStart,
   ) =>
@@ -87,15 +131,15 @@ class MockCalendarRepository extends _i1.Mock
               timeSpan,
               utcStart,
             ]),
-            returnValue: _i4.Future<List<_i3.UserCalendarEvent>>.value(
-              <_i3.UserCalendarEvent>[],
+            returnValue: _i5.Future<List<_i4.UserCalendarEvent>>.value(
+              <_i4.UserCalendarEvent>[],
             ),
           )
-          as _i4.Future<List<_i3.UserCalendarEvent>>);
+          as _i5.Future<List<_i4.UserCalendarEvent>>);
 
   @override
-  _i4.Future<List<_i3.UserCalendarEvent>> getEventsOnLocalDate(
-    List<_i3.UserCalendar>? selectedCalendars,
+  _i5.Future<List<_i4.UserCalendarEvent>> getEventsOnLocalDate(
+    List<_i4.UserCalendar>? selectedCalendars,
     int? offset,
   ) =>
       (super.noSuchMethod(
@@ -103,33 +147,33 @@ class MockCalendarRepository extends _i1.Mock
               selectedCalendars,
               offset,
             ]),
-            returnValue: _i4.Future<List<_i3.UserCalendarEvent>>.value(
-              <_i3.UserCalendarEvent>[],
+            returnValue: _i5.Future<List<_i4.UserCalendarEvent>>.value(
+              <_i4.UserCalendarEvent>[],
             ),
           )
-          as _i4.Future<List<_i3.UserCalendarEvent>>);
+          as _i5.Future<List<_i4.UserCalendarEvent>>);
 
   @override
-  _i4.Future<_i3.UserCalendarEvent?> getNextClassEvent(
-    List<_i3.UserCalendar>? selectedCalendars,
+  _i5.Future<_i4.UserCalendarEvent?> getNextClassEvent(
+    List<_i4.UserCalendar>? selectedCalendars,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassEvent, [selectedCalendars]),
-            returnValue: _i4.Future<_i3.UserCalendarEvent?>.value(),
+            returnValue: _i5.Future<_i4.UserCalendarEvent?>.value(),
           )
-          as _i4.Future<_i3.UserCalendarEvent?>);
+          as _i5.Future<_i4.UserCalendarEvent?>);
 
   @override
-  _i4.Future<_i5.ConcordiaRoom?> getNextClassRoom(
-    List<_i3.UserCalendar>? selectedCalendars,
-    _i6.BuildingViewModel? buildingViewModel,
+  _i5.Future<_i6.ConcordiaRoom?> getNextClassRoom(
+    List<_i4.UserCalendar>? selectedCalendars,
+    _i7.BuildingViewModel? buildingViewModel,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassRoom, [
               selectedCalendars,
               buildingViewModel,
             ]),
-            returnValue: _i4.Future<_i5.ConcordiaRoom?>.value(),
+            returnValue: _i5.Future<_i6.ConcordiaRoom?>.value(),
           )
-          as _i4.Future<_i5.ConcordiaRoom?>);
+          as _i5.Future<_i6.ConcordiaRoom?>);
 }

--- a/concordia_nav/test/indoor_map/indoor_routing_service_test.mocks.dart
+++ b/concordia_nav/test/indoor_map/indoor_routing_service_test.mocks.dart
@@ -3,17 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i5;
+import 'dart:async' as _i6;
 
-import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i8;
-import 'package:concordia_nav/data/repositories/calendar.dart' as _i7;
-import 'package:concordia_nav/utils/building_viewmodel.dart' as _i9;
+import 'package:concordia_nav/data/domain-model/concordia_room.dart' as _i9;
+import 'package:concordia_nav/data/repositories/calendar.dart' as _i8;
+import 'package:concordia_nav/utils/building_viewmodel.dart' as _i10;
 import 'package:device_calendar/device_calendar.dart' as _i3;
-import 'package:geolocator_platform_interface/src/enums/enums.dart' as _i6;
+import 'package:geolocator_platform_interface/src/enums/enums.dart' as _i7;
 import 'package:geolocator_platform_interface/src/geolocator_platform_interface.dart'
-    as _i4;
+    as _i5;
 import 'package:geolocator_platform_interface/src/models/models.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:shared_preferences/shared_preferences.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -40,64 +41,70 @@ class _FakeDeviceCalendarPlugin_1 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
+class _FakeSharedPreferencesAsync_2 extends _i1.SmartFake
+    implements _i4.SharedPreferencesAsync {
+  _FakeSharedPreferencesAsync_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [GeolocatorPlatform].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGeolocatorPlatform extends _i1.Mock
-    implements _i4.GeolocatorPlatform {
+    implements _i5.GeolocatorPlatform {
   MockGeolocatorPlatform() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i5.Future<_i6.LocationPermission> checkPermission() =>
+  _i6.Future<_i7.LocationPermission> checkPermission() =>
       (super.noSuchMethod(
             Invocation.method(#checkPermission, []),
-            returnValue: _i5.Future<_i6.LocationPermission>.value(
-              _i6.LocationPermission.denied,
+            returnValue: _i6.Future<_i7.LocationPermission>.value(
+              _i7.LocationPermission.denied,
             ),
           )
-          as _i5.Future<_i6.LocationPermission>);
+          as _i6.Future<_i7.LocationPermission>);
 
   @override
-  _i5.Future<_i6.LocationPermission> requestPermission() =>
+  _i6.Future<_i7.LocationPermission> requestPermission() =>
       (super.noSuchMethod(
             Invocation.method(#requestPermission, []),
-            returnValue: _i5.Future<_i6.LocationPermission>.value(
-              _i6.LocationPermission.denied,
+            returnValue: _i6.Future<_i7.LocationPermission>.value(
+              _i7.LocationPermission.denied,
             ),
           )
-          as _i5.Future<_i6.LocationPermission>);
+          as _i6.Future<_i7.LocationPermission>);
 
   @override
-  _i5.Future<bool> isLocationServiceEnabled() =>
+  _i6.Future<bool> isLocationServiceEnabled() =>
       (super.noSuchMethod(
             Invocation.method(#isLocationServiceEnabled, []),
-            returnValue: _i5.Future<bool>.value(false),
+            returnValue: _i6.Future<bool>.value(false),
           )
-          as _i5.Future<bool>);
+          as _i6.Future<bool>);
 
   @override
-  _i5.Future<_i2.Position?> getLastKnownPosition({
+  _i6.Future<_i2.Position?> getLastKnownPosition({
     bool? forceLocationManager = false,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getLastKnownPosition, [], {
               #forceLocationManager: forceLocationManager,
             }),
-            returnValue: _i5.Future<_i2.Position?>.value(),
+            returnValue: _i6.Future<_i2.Position?>.value(),
           )
-          as _i5.Future<_i2.Position?>);
+          as _i6.Future<_i2.Position?>);
 
   @override
-  _i5.Future<_i2.Position> getCurrentPosition({
+  _i6.Future<_i2.Position> getCurrentPosition({
     _i2.LocationSettings? locationSettings,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getCurrentPosition, [], {
               #locationSettings: locationSettings,
             }),
-            returnValue: _i5.Future<_i2.Position>.value(
+            returnValue: _i6.Future<_i2.Position>.value(
               _FakePosition_0(
                 this,
                 Invocation.method(#getCurrentPosition, [], {
@@ -106,67 +113,67 @@ class MockGeolocatorPlatform extends _i1.Mock
               ),
             ),
           )
-          as _i5.Future<_i2.Position>);
+          as _i6.Future<_i2.Position>);
 
   @override
-  _i5.Stream<_i6.ServiceStatus> getServiceStatusStream() =>
+  _i6.Stream<_i7.ServiceStatus> getServiceStatusStream() =>
       (super.noSuchMethod(
             Invocation.method(#getServiceStatusStream, []),
-            returnValue: _i5.Stream<_i6.ServiceStatus>.empty(),
+            returnValue: _i6.Stream<_i7.ServiceStatus>.empty(),
           )
-          as _i5.Stream<_i6.ServiceStatus>);
+          as _i6.Stream<_i7.ServiceStatus>);
 
   @override
-  _i5.Stream<_i2.Position> getPositionStream({
+  _i6.Stream<_i2.Position> getPositionStream({
     _i2.LocationSettings? locationSettings,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#getPositionStream, [], {
               #locationSettings: locationSettings,
             }),
-            returnValue: _i5.Stream<_i2.Position>.empty(),
+            returnValue: _i6.Stream<_i2.Position>.empty(),
           )
-          as _i5.Stream<_i2.Position>);
+          as _i6.Stream<_i2.Position>);
 
   @override
-  _i5.Future<_i6.LocationAccuracyStatus> requestTemporaryFullAccuracy({
+  _i6.Future<_i7.LocationAccuracyStatus> requestTemporaryFullAccuracy({
     required String? purposeKey,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#requestTemporaryFullAccuracy, [], {
               #purposeKey: purposeKey,
             }),
-            returnValue: _i5.Future<_i6.LocationAccuracyStatus>.value(
-              _i6.LocationAccuracyStatus.reduced,
+            returnValue: _i6.Future<_i7.LocationAccuracyStatus>.value(
+              _i7.LocationAccuracyStatus.reduced,
             ),
           )
-          as _i5.Future<_i6.LocationAccuracyStatus>);
+          as _i6.Future<_i7.LocationAccuracyStatus>);
 
   @override
-  _i5.Future<_i6.LocationAccuracyStatus> getLocationAccuracy() =>
+  _i6.Future<_i7.LocationAccuracyStatus> getLocationAccuracy() =>
       (super.noSuchMethod(
             Invocation.method(#getLocationAccuracy, []),
-            returnValue: _i5.Future<_i6.LocationAccuracyStatus>.value(
-              _i6.LocationAccuracyStatus.reduced,
+            returnValue: _i6.Future<_i7.LocationAccuracyStatus>.value(
+              _i7.LocationAccuracyStatus.reduced,
             ),
           )
-          as _i5.Future<_i6.LocationAccuracyStatus>);
+          as _i6.Future<_i7.LocationAccuracyStatus>);
 
   @override
-  _i5.Future<bool> openAppSettings() =>
+  _i6.Future<bool> openAppSettings() =>
       (super.noSuchMethod(
             Invocation.method(#openAppSettings, []),
-            returnValue: _i5.Future<bool>.value(false),
+            returnValue: _i6.Future<bool>.value(false),
           )
-          as _i5.Future<bool>);
+          as _i6.Future<bool>);
 
   @override
-  _i5.Future<bool> openLocationSettings() =>
+  _i6.Future<bool> openLocationSettings() =>
       (super.noSuchMethod(
             Invocation.method(#openLocationSettings, []),
-            returnValue: _i5.Future<bool>.value(false),
+            returnValue: _i6.Future<bool>.value(false),
           )
-          as _i5.Future<bool>);
+          as _i6.Future<bool>);
 
   @override
   double distanceBetween(
@@ -209,7 +216,7 @@ class MockGeolocatorPlatform extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCalendarRepository extends _i1.Mock
-    implements _i7.CalendarRepository {
+    implements _i8.CalendarRepository {
   MockCalendarRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -232,26 +239,63 @@ class MockCalendarRepository extends _i1.Mock
   );
 
   @override
-  _i5.Future<bool> checkPermissions() =>
+  _i4.SharedPreferencesAsync get prefs =>
       (super.noSuchMethod(
-            Invocation.method(#checkPermissions, []),
-            returnValue: _i5.Future<bool>.value(false),
-          )
-          as _i5.Future<bool>);
-
-  @override
-  _i5.Future<List<_i7.UserCalendar>> getUserCalendars() =>
-      (super.noSuchMethod(
-            Invocation.method(#getUserCalendars, []),
-            returnValue: _i5.Future<List<_i7.UserCalendar>>.value(
-              <_i7.UserCalendar>[],
+            Invocation.getter(#prefs),
+            returnValue: _FakeSharedPreferencesAsync_2(
+              this,
+              Invocation.getter(#prefs),
             ),
           )
-          as _i5.Future<List<_i7.UserCalendar>>);
+          as _i4.SharedPreferencesAsync);
 
   @override
-  _i5.Future<List<_i7.UserCalendarEvent>> getEvents(
-    List<_i7.UserCalendar>? selectedCalendars,
+  set prefs(_i4.SharedPreferencesAsync? _prefs) => super.noSuchMethod(
+    Invocation.setter(#prefs, _prefs),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i6.Future<bool> checkPermissions() =>
+      (super.noSuchMethod(
+            Invocation.method(#checkPermissions, []),
+            returnValue: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
+
+  @override
+  _i6.Future<List<_i8.UserCalendar>> getUserCalendars({
+    dynamic preferredCalendarsOnly = false,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#getUserCalendars, [], {
+              #preferredCalendarsOnly: preferredCalendarsOnly,
+            }),
+            returnValue: _i6.Future<List<_i8.UserCalendar>>.value(
+              <_i8.UserCalendar>[],
+            ),
+          )
+          as _i6.Future<List<_i8.UserCalendar>>);
+
+  @override
+  _i6.Future<bool> isCalendarPreferred(_i8.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#isCalendarPreferred, [cal]),
+            returnValue: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
+
+  @override
+  _i6.Future<bool> setUserCalendarPreferredState(_i8.UserCalendar? cal) =>
+      (super.noSuchMethod(
+            Invocation.method(#setUserCalendarPreferredState, [cal]),
+            returnValue: _i6.Future<bool>.value(false),
+          )
+          as _i6.Future<bool>);
+
+  @override
+  _i6.Future<List<_i8.UserCalendarEvent>> getEvents(
+    List<_i8.UserCalendar>? selectedCalendars,
     Duration? timeSpan,
     DateTime? utcStart,
   ) =>
@@ -261,15 +305,15 @@ class MockCalendarRepository extends _i1.Mock
               timeSpan,
               utcStart,
             ]),
-            returnValue: _i5.Future<List<_i7.UserCalendarEvent>>.value(
-              <_i7.UserCalendarEvent>[],
+            returnValue: _i6.Future<List<_i8.UserCalendarEvent>>.value(
+              <_i8.UserCalendarEvent>[],
             ),
           )
-          as _i5.Future<List<_i7.UserCalendarEvent>>);
+          as _i6.Future<List<_i8.UserCalendarEvent>>);
 
   @override
-  _i5.Future<List<_i7.UserCalendarEvent>> getEventsOnLocalDate(
-    List<_i7.UserCalendar>? selectedCalendars,
+  _i6.Future<List<_i8.UserCalendarEvent>> getEventsOnLocalDate(
+    List<_i8.UserCalendar>? selectedCalendars,
     int? offset,
   ) =>
       (super.noSuchMethod(
@@ -277,33 +321,33 @@ class MockCalendarRepository extends _i1.Mock
               selectedCalendars,
               offset,
             ]),
-            returnValue: _i5.Future<List<_i7.UserCalendarEvent>>.value(
-              <_i7.UserCalendarEvent>[],
+            returnValue: _i6.Future<List<_i8.UserCalendarEvent>>.value(
+              <_i8.UserCalendarEvent>[],
             ),
           )
-          as _i5.Future<List<_i7.UserCalendarEvent>>);
+          as _i6.Future<List<_i8.UserCalendarEvent>>);
 
   @override
-  _i5.Future<_i7.UserCalendarEvent?> getNextClassEvent(
-    List<_i7.UserCalendar>? selectedCalendars,
+  _i6.Future<_i8.UserCalendarEvent?> getNextClassEvent(
+    List<_i8.UserCalendar>? selectedCalendars,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassEvent, [selectedCalendars]),
-            returnValue: _i5.Future<_i7.UserCalendarEvent?>.value(),
+            returnValue: _i6.Future<_i8.UserCalendarEvent?>.value(),
           )
-          as _i5.Future<_i7.UserCalendarEvent?>);
+          as _i6.Future<_i8.UserCalendarEvent?>);
 
   @override
-  _i5.Future<_i8.ConcordiaRoom?> getNextClassRoom(
-    List<_i7.UserCalendar>? selectedCalendars,
-    _i9.BuildingViewModel? buildingViewModel,
+  _i6.Future<_i9.ConcordiaRoom?> getNextClassRoom(
+    List<_i8.UserCalendar>? selectedCalendars,
+    _i10.BuildingViewModel? buildingViewModel,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#getNextClassRoom, [
               selectedCalendars,
               buildingViewModel,
             ]),
-            returnValue: _i5.Future<_i8.ConcordiaRoom?>.value(),
+            returnValue: _i6.Future<_i9.ConcordiaRoom?>.value(),
           )
-          as _i5.Future<_i8.ConcordiaRoom?>);
+          as _i6.Future<_i9.ConcordiaRoom?>);
 }

--- a/concordia_nav/test/indoor_map/indoor_step_view_test.mocks.dart
+++ b/concordia_nav/test/indoor_map/indoor_step_view_test.mocks.dart
@@ -341,6 +341,37 @@ class MockVirtualStepGuideViewModel extends _i1.Mock
   );
 
   @override
+  String formatRoom(String? room) =>
+      (super.noSuchMethod(
+            Invocation.method(#formatRoom, [room]),
+            returnValue: _i7.dummyValue<String>(
+              this,
+              Invocation.method(#formatRoom, [room]),
+            ),
+          )
+          as String);
+
+  @override
+  String removeBuildingAbbreviation(
+    String? room,
+    String? buildingAbbreviation,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#removeBuildingAbbreviation, [
+              room,
+              buildingAbbreviation,
+            ]),
+            returnValue: _i7.dummyValue<String>(
+              this,
+              Invocation.method(#removeBuildingAbbreviation, [
+                room,
+                buildingAbbreviation,
+              ]),
+            ),
+          )
+          as String);
+
+  @override
   void calculateTimeAndDistanceEstimates() => super.noSuchMethod(
     Invocation.method(#calculateTimeAndDistanceEstimates, []),
     returnValueForMissingStub: null,

--- a/concordia_nav/test/settings/settingspage_test.dart
+++ b/concordia_nav/test/settings/settingspage_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:concordia_nav/data/repositories/calendar.dart';
 import 'package:concordia_nav/ui/setting/accessibility/accessibility_page.dart';
 import 'package:concordia_nav/ui/setting/calendar/calendar_link_view.dart';
@@ -9,10 +11,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:mockito/mockito.dart';
 
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+
 import '../calendar/calendar_repository_test.mocks.dart';
 import '../calendar/calendar_view_test.mocks.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
+
   group('SettingsPage', () {
     late MockDeviceCalendarPlugin mockPlugin;
 
@@ -30,18 +39,20 @@ void main() {
             .thenAnswer((_) async => Result<bool>()..data = true);
 
         // Arrange: CalendarSelectionViewModel mock
-        final MockCalendarSelectionViewModel mockSelectionViewModel = MockCalendarSelectionViewModel(); 
+        final MockCalendarSelectionViewModel mockSelectionViewModel =
+            MockCalendarSelectionViewModel();
         final calendar1 = UserCalendar('1', 'Calendar 1');
         final calendar2 = UserCalendar('2', 'Calendar 2');
         final calendars = [calendar1, calendar2];
-        when(mockSelectionViewModel.loadCalendars()).thenAnswer((_) async => {});
+        when(mockSelectionViewModel.loadCalendars())
+            .thenAnswer((_) async => {});
         when(mockSelectionViewModel.calendars).thenReturn(calendars);
 
         // define routes needed for this test
         final routes = {
           '/': (context) => SettingsPage(plugin: mockPlugin),
-          '/CalendarSelectionView': (context) => CalendarSelectionView(
-              calendarViewModel: mockSelectionViewModel),
+          '/CalendarSelectionView': (context) =>
+              CalendarSelectionView(calendarViewModel: mockSelectionViewModel),
         };
 
         // Build the SettingsPage widget

--- a/concordia_nav/test/widgets/indoor/location_selection_test.dart
+++ b/concordia_nav/test/widgets/indoor/location_selection_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:concordia_nav/widgets/next_class/location_selection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -5,8 +7,13 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
 
   dotenv.load(fileName: '.env');
 

--- a/concordia_nav/test/widgets/journey/next_class_directions_view_test.dart
+++ b/concordia_nav/test/widgets/journey/next_class_directions_view_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: depend_on_referenced_packages
+
 import 'package:concordia_nav/data/domain-model/concordia_floor.dart';
 import 'package:concordia_nav/data/domain-model/concordia_floor_point.dart';
 import 'package:concordia_nav/data/domain-model/concordia_room.dart';
@@ -14,11 +16,15 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:mockito/mockito.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
 
 import '../../map/map_viewmodel_test.mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferencesAsyncPlatform.instance =
+      InMemorySharedPreferencesAsync.empty();
   dotenv.load(fileName: '.env');
 
   final testPosition = Position(


### PR DESCRIPTION
### 🛠 Proposed Changes:

Add support for user settings

### 📝 Details:

This commit adds the [shared_preferences](https://pub.dev/packages/shared_preferences) package to the build which allows persisting defaults using the platform-specific patterns on iOS and Android. It supports many data types like string, number, bool, etc. but is a key-value store (no specific schema enforced). In general, people should depend directly on this package.

**The android build needs to be checked** because this package has native dependencies. I committed the iOS pubspec files but if the build is super broken it might be easier to start over with the repo files (since CI is android) and `pub add shared_preferences` again.

Additionally this commit implements shared_preferences in the CalendarRepository class. The UserCalendar class now has an attribute isPreferred, which defaults to true the first time a calendar is seen (and is persisted as true on first access). This corresponds to a calendar being "checked" or enabled in the UI. In the settings UI, the calendars should be displayed in a toggle-able fashion and if the toggle is modified by the user, the setUserCalendarPreferredState method should be called to persist this change in the settings. It also changes the getNextClassRoom method to only use preferred calendars in defining the user's location.

I did notice that the calendar settings code seems to be interfacing with DeviceCalendar directly rather than going through the repository, so there might need to be some refactoring done over there to fully integrate with the repository (in addition to the UI changes to add toggles). 

### 🔗 Related Issue(s):

- Resolves #322 
- Possibly relates to #288 but I think that issue is stale